### PR TITLE
Add ETF backtesting framework

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,3 +23,4 @@ testpaths = ["tests"]
 python_version = "3.11"
 strict = true
 files = ["src"]
+mypy_path = "src"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,7 @@
 ruff
 pytest
+pandas
+yfinance
 mypy
+pandas-stubs
+pyarrow

--- a/scripts/backtest.py
+++ b/scripts/backtest.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime
+from importlib import import_module
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from data import DataDownloader
+from engine import Backtester
+from strategies.base import Strategy
+
+
+def load_strategy(name: str, params: dict[str, float]) -> Strategy:
+    module = import_module(f"strategies.{name}")
+    cls = getattr(module, "Strategy")
+    return cls(**params)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run a strategy back-test")
+    parser.add_argument("--strategy", required=True, help="Strategy module name")
+    parser.add_argument("--ticker", required=True, help="Ticker symbol")
+    parser.add_argument("--start", required=True, help="Start date YYYY-MM-DD")
+    parser.add_argument("--end", required=True, help="End date YYYY-MM-DD")
+    parser.add_argument("--params", default="{}", help="JSON encoded parameters")
+    args = parser.parse_args()
+
+    params = json.loads(args.params)
+
+    strategy = load_strategy(args.strategy, params)
+    downloader = DataDownloader()
+    data = downloader.get_history(args.ticker, args.start, args.end)
+
+    backtester = Backtester(strategy, data)
+    results = backtester.run()
+
+    duration_years = (
+        datetime.fromisoformat(args.end) - datetime.fromisoformat(args.start)
+    ).days / 365.25
+    cagr = results["equity"].iloc[-1] ** (1 / duration_years) - 1
+    print(f"CAGR: {cagr:.2%}")
+    print(f"Final equity: {results['equity'].iloc[-1]:.2f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/signal.py
+++ b/scripts/signal.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import argparse
+import sys
+from datetime import datetime, timedelta
+from importlib import import_module
+from pathlib import Path
+
+from data import DataDownloader
+from strategies.base import Strategy
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+
+def load_strategy(name: str) -> Strategy:
+    module = import_module(f"strategies.{name}")
+    cls = getattr(module, "Strategy")
+    return cls()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Show latest trading signal")
+    parser.add_argument("--strategy", required=True, help="Strategy module name")
+    parser.add_argument("--ticker", required=True, help="Ticker symbol")
+    parser.add_argument(
+        "--lookback",
+        type=int,
+        default=365,
+        help="Lookback period in days",
+    )
+    args = parser.parse_args()
+
+    end = datetime.utcnow().date()
+    start = end - timedelta(days=args.lookback)
+
+    downloader = DataDownloader()
+    data = downloader.get_history(args.ticker, str(start), str(end))
+    strategy = load_strategy(args.strategy)
+
+    signal = "HOLD"
+    for _, bar in data.iterrows():
+        signal = strategy.next_bar(bar)
+
+    print(signal)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/data.py
+++ b/src/data.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+import yfinance as yf  # type: ignore
+
+
+class DataDownloader:
+    """Download and cache historical OHLCV data."""
+
+    def __init__(self, cache_dir: Path | None = None) -> None:
+        self.cache_dir = cache_dir or Path("data")
+        self.cache_dir.mkdir(exist_ok=True)
+
+    def get_history(self, ticker: str, start: str, end: str) -> pd.DataFrame:
+        """Return historical data for *ticker* between *start* and *end*.
+
+        Parameters
+        ----------
+        ticker:
+            Ticker symbol understood by yfinance.
+        start:
+            Inclusive start date in ``YYYY-MM-DD`` format.
+        end:
+            Exclusive end date in ``YYYY-MM-DD`` format.
+        """
+        cache_file = self.cache_dir / f"{ticker}.parquet"
+        if cache_file.exists():
+            df = pd.read_parquet(cache_file)
+        else:
+            df = yf.download(ticker, start=start, end=end, progress=False)
+            df.to_parquet(cache_file)
+        df.index.name = "date"
+        df = df.loc[pd.Timestamp(start) : pd.Timestamp(end)]
+        if isinstance(df.columns, pd.MultiIndex):
+            df.columns = df.columns.get_level_values(0)
+        df.columns = [str(c).lower() for c in df.columns]
+        return df

--- a/src/engine.py
+++ b/src/engine.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from typing import List
+
+import pandas as pd
+
+from strategies.base import Strategy
+
+
+class Backtester:
+    """Simple long-only back-testing engine."""
+
+    def __init__(self, strategy: Strategy, data: pd.DataFrame) -> None:
+        self.strategy = strategy
+        self.data = data
+        self.position = 0
+        self.equity = 1.0
+        self.trades: List[tuple[str, pd.Timestamp, float]] = []
+
+    def run(self) -> pd.DataFrame:
+        """Run the back-test and return equity curve."""
+        self.strategy.reset()
+        results = []
+        peak = self.equity
+        prev_close: float | None = None
+        for date, row in self.data.iterrows():
+            ts = pd.Timestamp(str(date))
+            signal = self.strategy.next_bar(row)
+            price = float(row["close"])
+            if signal == "BUY" and self.position == 0:
+                self.position = 1
+                self.trades.append(("BUY", ts, price))
+            elif signal == "SELL" and self.position == 1:
+                self.position = 0
+                self.trades.append(("SELL", ts, price))
+            if prev_close is None:
+                ret = 0.0
+            else:
+                ret = (price - prev_close) / prev_close
+            self.equity *= 1 + ret * self.position
+            peak = max(peak, self.equity)
+            drawdown = self.equity / peak - 1
+            results.append(
+                {
+                    "date": ts,
+                    "price": price,
+                    "position": self.position,
+                    "signal": signal,
+                    "equity": self.equity,
+                    "drawdown": drawdown,
+                }
+            )
+            prev_close = price
+        return pd.DataFrame(results).set_index("date")

--- a/src/strategies/base.py
+++ b/src/strategies/base.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any
+
+import pandas as pd
+
+
+class Strategy(ABC):
+    """Base class for trading strategies."""
+
+    def __init__(self, **params: Any) -> None:
+        self.params = params
+        self.reset()
+
+    def reset(self) -> None:
+        """Reset internal state for a new back-test."""
+        self.position = 0
+        self.today: pd.Timestamp | None = None
+
+    @abstractmethod
+    def next_bar(self, bar: pd.Series[Any]) -> str:
+        """Process the next market bar and return a trading signal."""
+        raise NotImplementedError

--- a/tests/test_framework.py
+++ b/tests/test_framework.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+import pandas as pd
+
+from data import DataDownloader
+from engine import Backtester
+from strategies.base import Strategy
+
+
+def test_downloader_caches(tmp_path: Path) -> None:
+    downloader = DataDownloader(cache_dir=tmp_path)
+
+    df = downloader.get_history("SPY", "2020-01-01", "2020-01-10")
+    assert (tmp_path / "SPY.parquet").exists()
+    df2 = downloader.get_history("SPY", "2020-01-01", "2020-01-10")
+    assert len(df) == len(df2)
+
+
+class DummyStrategy(Strategy):
+    def next_bar(self, bar: pd.Series) -> str:
+        return "HOLD"
+
+
+def test_backtester_length(tmp_path: Path) -> None:
+    downloader = DataDownloader(cache_dir=tmp_path)
+    data = downloader.get_history("SPY", "2020-01-01", "2020-01-10")
+
+    strategy = DummyStrategy()
+    bt = Backtester(strategy, data)
+    results = bt.run()
+    assert len(results) == len(data)


### PR DESCRIPTION
## Summary
- implement a cached `DataDownloader`
- create abstract `Strategy` base class
- implement `Backtester` engine
- add CLI utilities `backtest.py` and `signal.py`
- include basic tests for caching and engine output length
- configure mypy search path and development dependencies

## Testing
- `ruff check .`
- `mypy`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862dffc6cc48323a01b887c8bd92421