### PR TITLE
Add IBS strategy implementation

### DIFF
--- a/src/strategies/__init__.py
+++ b/src/strategies/__init__.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+from .ibs import IBSStrategy
+
+STRATEGIES = {
+    "ibs": IBSStrategy,
+}
+
+__all__ = ["IBSStrategy", "STRATEGIES"]

--- a/src/strategies/ibs.py
+++ b/src/strategies/ibs.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pandas as pd
+
+from .base import Strategy as BaseStrategy
+
+
+class IBSStrategy(BaseStrategy):
+    """Internal Bar Strength strategy."""
+
+    def __init__(self, buy_thr: float = 0.2, sell_thr: float = 0.8) -> None:
+        super().__init__(buy_thr=buy_thr, sell_thr=sell_thr)
+        self.buy_thr = buy_thr
+        self.sell_thr = sell_thr
+
+    def next_bar(self, bar: pd.Series[Any]) -> str:
+        """Return trading signal based on IBS."""
+        high = float(bar["high"])
+        low = float(bar["low"])
+        close = float(bar["close"])
+
+        if high == low:
+            ibs = 0.5
+        else:
+            ibs = (close - low) / (high - low)
+
+        if ibs <= self.buy_thr:
+            return "BUY"
+        if ibs >= self.sell_thr:
+            return "SELL"
+        return "HOLD"

--- a/tests/test_ibs.py
+++ b/tests/test_ibs.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from strategies.ibs import IBSStrategy  # noqa: E402
+
+
+def test_ibs_signals() -> None:
+    strategy = IBSStrategy(buy_thr=0.2, sell_thr=0.8)
+    bars = [
+        pd.Series({"open": 0, "high": 10, "low": 0, "close": 2}),
+        pd.Series({"open": 0, "high": 10, "low": 0, "close": 8}),
+        pd.Series({"open": 0, "high": 10, "low": 0, "close": 5}),
+    ]
+
+    signals = [strategy.next_bar(bar) for bar in bars]
+
+    assert signals == ["BUY", "SELL", "HOLD"]


### PR DESCRIPTION
## Summary
- implement Internal Bar Strength strategy
- register strategy in strategies package
- test buy/sell/hold signals

## Testing
- `ruff check .`
- `mypy`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862e703bb9c83238e2021c39744ca2e