### PR TITLE
Add weekly RSI mean-reversion strategy

### DIFF
--- a/src/strategies/__init__.py
+++ b/src/strategies/__init__.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 from .ibs import IBSStrategy
+from .rsi import RSIStrategy
 
 STRATEGIES = {
     "ibs": IBSStrategy,
+    "rsi": RSIStrategy,
 }
 
-__all__ = ["IBSStrategy", "STRATEGIES"]
+__all__ = ["IBSStrategy", "RSIStrategy", "STRATEGIES"]

--- a/src/strategies/rsi.py
+++ b/src/strategies/rsi.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pandas as pd
+
+from .base import Strategy as BaseStrategy
+
+
+def wilder_rsi(series: pd.Series[float], length: int = 14) -> pd.Series[float]:
+    """Compute Wilder's RSI."""
+    delta = series.diff()
+    gain = delta.clip(lower=0)
+    loss = -delta.clip(upper=0)
+
+    avg_gain = gain.ewm(alpha=1 / length, min_periods=length, adjust=False).mean()
+    avg_loss = loss.ewm(alpha=1 / length, min_periods=length, adjust=False).mean()
+
+    rs = avg_gain / avg_loss
+    rsi = 100 - 100 / (1 + rs)
+    zero_mask = (avg_gain == 0) & (avg_loss == 0)
+    rsi = rsi.where(~zero_mask, 50.0)
+    return rsi
+
+
+class RSIStrategy(BaseStrategy):
+    """Weekly RSI mean-reversion strategy."""
+
+    def __init__(
+        self, rsi_buy: float = 30, rsi_sell: float = 70, length: int = 14
+    ) -> None:
+        super().__init__(rsi_buy=rsi_buy, rsi_sell=rsi_sell, length=length)
+        self.rsi_buy = rsi_buy
+        self.rsi_sell = rsi_sell
+        self.length = length
+        self._close_history = pd.Series(dtype=float)
+
+    def reset(self) -> None:
+        super().reset()
+        self._close_history = pd.Series(dtype=float)
+
+    def next_bar(self, bar: pd.Series[Any]) -> str:
+        """Return trading signal based on weekly RSI."""
+        if not isinstance(bar.name, pd.Timestamp):
+            raise ValueError("Bar index must be a pd.Timestamp for RSI strategy")
+        close = float(bar["close"])
+        self._close_history.at[bar.name] = close
+
+        weekly_close = self._close_history.resample("W-FRI").last()
+        rsi_series = wilder_rsi(weekly_close, self.length)
+        clean_rsi = rsi_series.dropna()
+        rsi_value = clean_rsi.iloc[-1] if not clean_rsi.empty else None
+
+        if rsi_value is None:
+            return "HOLD"
+        if rsi_value <= self.rsi_buy:
+            return "BUY"
+        if rsi_value >= self.rsi_sell:
+            return "SELL"
+        return "HOLD"

--- a/tests/test_rsi.py
+++ b/tests/test_rsi.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from strategies.rsi import RSIStrategy, wilder_rsi  # noqa: E402
+
+
+def test_wilder_rsi_constant_series() -> None:
+    index = pd.date_range("2023-01-06", periods=20, freq="W-FRI")
+    series = pd.Series(100.0, index=index)
+    rsi = wilder_rsi(series, length=14)
+    assert rsi.dropna().iloc[-1] == 50
+
+
+def test_rsi_strategy_signals() -> None:
+    index = pd.date_range("2023-01-02", periods=30, freq="B")
+    close = pd.Series(range(30), index=index, name="close")
+    data = pd.DataFrame({"close": close})
+    strategy = RSIStrategy(rsi_buy=30, rsi_sell=70, length=2)
+    signals = [strategy.next_bar(row) for _, row in data.iterrows()]
+    assert signals[0] == "HOLD"
+    assert "BUY" in signals or "SELL" in signals


### PR DESCRIPTION
## Summary
- implement `RSIStrategy` with Wilder RSI computed on weekly bars
- expose `RSIStrategy` via strategy registry
- add unit tests for RSI edge case and example signals

## Testing
- `ruff check .`
- `mypy src`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862e898015c8323a84b5fed2bba51cf