### PR TITLE
Add parameter-grid sweep and --all strategy runner

### DIFF
--- a/scripts/backtest.py
+++ b/scripts/backtest.py
@@ -1,17 +1,40 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
+import itertools
 import json
 import sys
-from datetime import datetime
 from importlib import import_module
 from pathlib import Path
+from typing import Any
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 
 from data import DataDownloader
 from engine import Backtester
+from metrics import cagr, max_drawdown
+from strategies import STRATEGIES
 from strategies.base import Strategy
+
+
+def generate_param_grid(params: dict[str, Any]) -> list[dict[str, Any]]:
+    """Return cartesian product of parameter values.
+
+    Any value that is a list will be expanded. Single values are kept as-is.
+    """
+    keys = list(params.keys())
+    values: list[list[Any]] = []
+    for v in params.values():
+        if isinstance(v, list):
+            values.append(v)
+        else:
+            values.append([v])
+
+    grid = []
+    for combo in itertools.product(*values):
+        grid.append(dict(zip(keys, combo)))
+    return grid
 
 
 def load_strategy(name: str, params: dict[str, float]) -> Strategy:
@@ -22,28 +45,55 @@ def load_strategy(name: str, params: dict[str, float]) -> Strategy:
 
 def main() -> None:
     parser = argparse.ArgumentParser(description="Run a strategy back-test")
-    parser.add_argument("--strategy", required=True, help="Strategy module name")
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--strategy", help="Strategy module name")
+    group.add_argument("--all", action="store_true", help="Run all strategies")
     parser.add_argument("--ticker", required=True, help="Ticker symbol")
     parser.add_argument("--start", required=True, help="Start date YYYY-MM-DD")
     parser.add_argument("--end", required=True, help="End date YYYY-MM-DD")
     parser.add_argument("--params", default="{}", help="JSON encoded parameters")
+    parser.add_argument("--sweep", action="store_true", help="Run parameter sweep")
     args = parser.parse_args()
 
-    params = json.loads(args.params)
+    base_params: dict[str, Any] = json.loads(args.params)
 
-    strategy = load_strategy(args.strategy, params)
-    downloader = DataDownloader()
-    data = downloader.get_history(args.ticker, args.start, args.end)
+    strategies: list[str]
+    if args.all:
+        strategies = list(STRATEGIES.keys())
+    else:
+        strategies = [args.strategy]
 
-    backtester = Backtester(strategy, data)
-    results = backtester.run()
+    summary: list[tuple[str, str, float, float]] = []
+    results_dir = Path("results")
+    results_dir.mkdir(exist_ok=True)
 
-    duration_years = (
-        datetime.fromisoformat(args.end) - datetime.fromisoformat(args.start)
-    ).days / 365.25
-    cagr = results["equity"].iloc[-1] ** (1 / duration_years) - 1
-    print(f"CAGR: {cagr:.2%}")
-    print(f"Final equity: {results['equity'].iloc[-1]:.2f}")
+    for strat_name in strategies:
+        param_sets = (
+            generate_param_grid(base_params) if args.sweep else [base_params]
+        )
+        for params in param_sets:
+            strategy = load_strategy(strat_name, params)
+            downloader = DataDownloader()
+            data = downloader.get_history(args.ticker, args.start, args.end)
+            backtester = Backtester(strategy, data)
+            results = backtester.run()
+
+            cagr_value = cagr(results["equity"], args.start, args.end)
+            max_dd = max_drawdown(results["drawdown"])
+
+            paramhash = hashlib.md5(
+                json.dumps(params, sort_keys=True).encode()
+            ).hexdigest()[:8]
+            out_file = (
+                results_dir
+                / f"{strat_name}_{paramhash}_{args.ticker}.csv"
+            )
+            results.to_csv(out_file)
+            summary.append((strat_name, paramhash, cagr_value, max_dd))
+
+    print("strategy  params    CAGR     MaxDD")
+    for strat, phash, cg, dd in summary:
+        print(f"{strat:<8} {phash:<8} {cg:>7.2%} {dd:>9.2%}")
 
 
 if __name__ == "__main__":

--- a/src/metrics.py
+++ b/src/metrics.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from math import sqrt
+from typing import Any
+
+import pandas as pd
+
+
+def cagr(
+    equity: pd.Series[Any], start: str | pd.Timestamp, end: str | pd.Timestamp
+) -> float:
+    """Compute Compound Annual Growth Rate for *equity* between *start* and *end*."""
+    start_ts = pd.Timestamp(start)
+    end_ts = pd.Timestamp(end)
+    years = (end_ts - start_ts).days / 365.25
+    if years == 0:
+        return 0.0
+    final_equity = float(equity.iloc[-1])
+    return float(final_equity ** (1 / years) - 1)
+
+
+def sharpe_ratio(
+    returns: pd.Series[float], risk_free_rate: float = 0.0, periods_per_year: int = 252
+) -> float:
+    """Return annualized Sharpe ratio of *returns*."""
+    if returns.empty:
+        return 0.0
+    excess = returns - risk_free_rate / periods_per_year
+    std = float(excess.std(ddof=0))
+    if std == 0:
+        return 0.0
+    mean = float(excess.mean())
+    return mean / std * sqrt(periods_per_year)
+
+
+def max_drawdown(drawdown: pd.Series[float]) -> float:
+    """Return maximum drawdown from a drawdown series."""
+    if drawdown.empty:
+        return 0.0
+    return float(drawdown.min())

--- a/tests/test_param_grid.py
+++ b/tests/test_param_grid.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(project_root / "src"))
+sys.path.insert(0, str(project_root))
+
+from scripts.backtest import generate_param_grid  # noqa: E402
+
+
+def test_generate_param_grid() -> None:
+    params = {"a": [1, 2], "b": 3, "c": [4, 5]}
+    grid = generate_param_grid(params)
+    expected = [
+        {"a": 1, "b": 3, "c": 4},
+        {"a": 1, "b": 3, "c": 5},
+        {"a": 2, "b": 3, "c": 4},
+        {"a": 2, "b": 3, "c": 5},
+    ]
+    assert grid == expected


### PR DESCRIPTION
## Summary
- implement metric utilities for CAGR, Sharpe and drawdown
- expand backtesting CLI to run all strategies and parameter sweeps
- provide util `generate_param_grid`
- test the parameter grid generator

## Testing
- `ruff check .`
- `mypy`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6862eb0329fc8323a65425693514431f