### PR TITLE
Add MACD crossover strategy

### DIFF
--- a/src/strategies/__init__.py
+++ b/src/strategies/__init__.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
 from .ibs import IBSStrategy
+from .macd import MACDStrategy
 from .rsi import RSIStrategy
 
 STRATEGIES = {
     "ibs": IBSStrategy,
+    "macd": MACDStrategy,
     "rsi": RSIStrategy,
 }
 
-__all__ = ["IBSStrategy", "RSIStrategy", "STRATEGIES"]
+__all__ = ["IBSStrategy", "MACDStrategy", "RSIStrategy", "STRATEGIES"]

--- a/src/strategies/macd.py
+++ b/src/strategies/macd.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pandas as pd
+
+from .base import Strategy as BaseStrategy
+
+
+class MACDStrategy(BaseStrategy):
+    """Moving Average Convergence Divergence crossover strategy."""
+
+    def __init__(self, fast: int = 12, slow: int = 26, signal: int = 9) -> None:
+        super().__init__(fast=fast, slow=slow, signal=signal)
+        self.fast = fast
+        self.slow = slow
+        self.signal = signal
+        self._close_history = pd.Series(dtype=float)
+
+    def reset(self) -> None:
+        super().reset()
+        self._close_history = pd.Series(dtype=float)
+
+    def next_bar(self, bar: pd.Series[Any]) -> str:
+        if not isinstance(bar.name, pd.Timestamp):
+            raise ValueError("Bar index must be a pd.Timestamp for MACD strategy")
+        close = float(bar["close"])
+        self._close_history.at[bar.name] = close
+
+        weekly_close = self._close_history.resample("W-FRI").last()
+        ema_fast = weekly_close.ewm(span=self.fast, adjust=False).mean()
+        ema_slow = weekly_close.ewm(span=self.slow, adjust=False).mean()
+        macd_line = ema_fast - ema_slow
+        signal_line = macd_line.ewm(span=self.signal, adjust=False).mean()
+
+        if len(macd_line) < 2:
+            return "HOLD"
+
+        prev_macd = macd_line.iloc[-2]
+        prev_signal = signal_line.iloc[-2]
+        curr_macd = macd_line.iloc[-1]
+        curr_signal = signal_line.iloc[-1]
+
+        if prev_macd <= prev_signal and curr_macd > curr_signal:
+            return "BUY"
+        if prev_macd >= prev_signal and curr_macd < curr_signal:
+            return "SELL"
+        return "HOLD"

--- a/tests/test_macd.py
+++ b/tests/test_macd.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from strategies.macd import MACDStrategy  # noqa: E402
+
+
+def test_macd_strategy_signals() -> None:
+    index = pd.date_range("2023-01-02", periods=20, freq="B")
+    closes = [1] * 5 + [10] * 5 + [5] * 5 + [15] * 5
+    data = pd.DataFrame({"close": closes}, index=index)
+    strategy = MACDStrategy(fast=2, slow=3, signal=2)
+
+    signals = [strategy.next_bar(row) for _, row in data.iterrows()]
+
+    assert "BUY" in signals and "SELL" in signals


### PR DESCRIPTION
## Summary
- add a MACD crossover strategy working on weekly bars
- register the strategy in the strategy registry
- test MACD strategy

## Testing
- `ruff check .`
- `mypy`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862ed57d6108323a10e63ccf828e518