### PR TITLE
Add breakout strategy

### DIFF
--- a/src/strategies/__init__.py
+++ b/src/strategies/__init__.py
@@ -1,13 +1,21 @@
 from __future__ import annotations
 
+from .breakout import BreakoutStrategy
 from .ibs import IBSStrategy
 from .macd import MACDStrategy
 from .rsi import RSIStrategy
 
 STRATEGIES = {
+    "breakout": BreakoutStrategy,
     "ibs": IBSStrategy,
     "macd": MACDStrategy,
     "rsi": RSIStrategy,
 }
 
-__all__ = ["IBSStrategy", "MACDStrategy", "RSIStrategy", "STRATEGIES"]
+__all__ = [
+    "BreakoutStrategy",
+    "IBSStrategy",
+    "MACDStrategy",
+    "RSIStrategy",
+    "STRATEGIES",
+]

--- a/src/strategies/breakout.py
+++ b/src/strategies/breakout.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pandas as pd
+
+from .base import Strategy as BaseStrategy
+
+
+class BreakoutStrategy(BaseStrategy):
+    """52-week high breakout momentum strategy."""
+
+    def __init__(self, lookback_weeks: int = 52, stop_pct: float = 0.08) -> None:
+        super().__init__(lookback_weeks=lookback_weeks, stop_pct=stop_pct)
+        self.lookback_weeks = lookback_weeks
+        self.stop_pct = stop_pct
+        self._close_history = pd.Series(dtype=float)
+        self._highest_close: float | None = None
+
+    def reset(self) -> None:
+        super().reset()
+        self._close_history = pd.Series(dtype=float)
+        self._highest_close = None
+
+    def next_bar(self, bar: pd.Series[Any]) -> str:
+        """Return trading signal based on breakout logic."""
+        if not isinstance(bar.name, pd.Timestamp):
+            raise ValueError("Bar index must be a pd.Timestamp for Breakout strategy")
+        close = float(bar["close"])
+        self._close_history.at[bar.name] = close
+
+        weekly_close = self._close_history.resample("W-FRI").last()
+        current_week_close = float(weekly_close.iloc[-1])
+        lookback_window = weekly_close.iloc[-self.lookback_weeks - 1 : -1]
+        if lookback_window.empty:
+            highest_weekly_close = float("-inf")
+        else:
+            highest_weekly_close = float(lookback_window.max())
+
+        sma_200 = self._close_history.rolling(window=200).mean().iloc[-1]
+        sma_200_value: float | None = (
+            float(sma_200) if not pd.isna(sma_200) else None
+        )
+
+        signal = "HOLD"
+        if self.position == 0:
+            if current_week_close > highest_weekly_close:
+                signal = "BUY"
+                self.position = 1
+                self._highest_close = current_week_close
+        else:
+            if self._highest_close is None:
+                self._highest_close = current_week_close
+            self._highest_close = max(self._highest_close, current_week_close)
+            stop_level = self._highest_close * (1 - self.stop_pct)
+            if current_week_close < stop_level:
+                signal = "SELL"
+                self.position = 0
+                self._highest_close = None
+            elif sma_200_value is not None and close < sma_200_value:
+                signal = "SELL"
+                self.position = 0
+                self._highest_close = None
+        return signal
+

--- a/tests/test_breakout.py
+++ b/tests/test_breakout.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from strategies.breakout import BreakoutStrategy  # noqa: E402
+
+
+def test_breakout_buy_and_stop() -> None:
+    index = pd.date_range("2023-01-02", periods=20, freq="B")
+    closes = [100] * 10 + [110] * 5 + [90] * 5
+    data = pd.DataFrame({"close": closes}, index=index)
+
+    strategy = BreakoutStrategy(lookback_weeks=2, stop_pct=0.1)
+    signals = [strategy.next_bar(row) for _, row in data.iterrows()]
+
+    assert "BUY" in signals
+    assert "SELL" in signals
+
+
+def test_breakout_sma_exit() -> None:
+    index = pd.date_range("2023-01-02", periods=202, freq="B")
+    closes = [100.0] * 200 + [110.0, 99.5]
+    data = pd.DataFrame({"close": closes}, index=index)
+
+    strategy = BreakoutStrategy(lookback_weeks=1, stop_pct=0.1)
+    signals = [strategy.next_bar(row) for _, row in data.iterrows()]
+
+    assert signals[-1] == "SELL"
+


### PR DESCRIPTION
## Summary
- implement 52-week-high breakout strategy with trailing stop and 200d SMA exit
- register breakout strategy
- add unit tests

## Testing
- `ruff check .`
- `mypy`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862f1bcf93083239485e335438ac410