### PR TITLE
Fix script import order

### DIFF
--- a/scripts/signal.py
+++ b/scripts/signal.py
@@ -1,15 +1,17 @@
 from __future__ import annotations
 
 import argparse
+import signal as _signal
 import sys
 from datetime import datetime, timedelta
 from importlib import import_module
 from pathlib import Path
 
-from data import DataDownloader
-from strategies.base import Strategy
-
+sys.modules["signal"] = _signal
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from data import DataDownloader  # noqa: E402
+from strategies.base import Strategy  # noqa: E402
 
 
 def load_strategy(name: str) -> Strategy:


### PR DESCRIPTION
## Summary
- move `sys.path` update before importing local modules
- ensure built-in `signal` module loads correctly

## Testing
- `ruff check .`
- `mypy`
- `pytest -q`
- `python scripts/signal.py --help`

------
https://chatgpt.com/codex/tasks/task_e_6862f346e2048323a1847781c845dbc3