### PR TITLE
Add dual momentum ETF rotation strategy

### DIFF
--- a/src/engine.py
+++ b/src/engine.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import List
+from typing import Dict, List
 
 import pandas as pd
 
@@ -14,32 +14,70 @@ class Backtester:
         self.strategy = strategy
         self.data = data
         self.position = 0
+        self.symbol: str | None = None
         self.equity = 1.0
-        self.trades: List[tuple[str, pd.Timestamp, float]] = []
+        self.trades: List[tuple[str, str, pd.Timestamp, float]] = []
+        self._multi_asset = "close" not in self.data.columns
 
     def run(self) -> pd.DataFrame:
         """Run the back-test and return equity curve."""
         self.strategy.reset()
         results = []
         peak = self.equity
-        prev_close: float | None = None
+        prev_close: Dict[str, float | None] = {
+            col: None for col in self.data.columns
+        }
         for date, row in self.data.iterrows():
             ts = pd.Timestamp(str(date))
-            signal = self.strategy.next_bar(row)
-            price = float(row["close"])
-            if signal == "BUY" and self.position == 0:
-                self.position = 1
-                self.trades.append(("BUY", ts, price))
-            elif signal == "SELL" and self.position == 1:
-                self.position = 0
-                self.trades.append(("SELL", ts, price))
-            if prev_close is None:
-                ret = 0.0
+
+            # compute return for current holding before processing today's signal
+            if self.position == 1 and self.symbol is not None:
+                price = float(row[self.symbol])
+                pc = prev_close.get(self.symbol)
+                ret = 0.0 if pc is None else (price - pc) / pc
             else:
-                ret = (price - prev_close) / prev_close
-            self.equity *= 1 + ret * self.position
+                price = float(row["close"]) if not self._multi_asset else 0.0
+                ret = 0.0
+
+            self.equity *= 1 + ret
             peak = max(peak, self.equity)
             drawdown = self.equity / peak - 1
+
+            signal = self.strategy.next_bar(row)
+
+            if self._multi_asset:
+                if signal.startswith("BUY:"):
+                    ticker = signal.split(":", 1)[1]
+                    if (
+                        self.position == 1
+                        and self.symbol is not None
+                        and self.symbol != ticker
+                    ):
+                        sell_price = float(row[self.symbol])
+                        self.trades.append(("SELL", self.symbol, ts, sell_price))
+                    if self.symbol != ticker:
+                        buy_price = float(row[ticker])
+                        self.trades.append(("BUY", ticker, ts, buy_price))
+                        self.position = 1
+                        self.symbol = ticker
+                elif signal.startswith("SELL:"):
+                    ticker = signal.split(":", 1)[1]
+                    if self.position == 1 and self.symbol == ticker:
+                        sell_price = float(row[ticker])
+                        self.trades.append(("SELL", ticker, ts, sell_price))
+                        self.position = 0
+                        self.symbol = None
+            else:
+                if signal == "BUY" and self.position == 0:
+                    self.position = 1
+                    self.symbol = "close"
+                    buy_price = float(row["close"])
+                    self.trades.append(("BUY", "close", ts, buy_price))
+                elif signal == "SELL" and self.position == 1:
+                    self.position = 0
+                    sell_price = float(row["close"])
+                    self.trades.append(("SELL", "close", ts, sell_price))
+
             results.append(
                 {
                     "date": ts,
@@ -50,5 +88,8 @@ class Backtester:
                     "drawdown": drawdown,
                 }
             )
-            prev_close = price
+
+            for col in self.data.columns:
+                prev_close[col] = float(row[col])
+
         return pd.DataFrame(results).set_index("date")

--- a/src/strategies/__init__.py
+++ b/src/strategies/__init__.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
 from .breakout import BreakoutStrategy
+from .dual_mom import DualMomentumStrategy
 from .ibs import IBSStrategy
 from .macd import MACDStrategy
 from .rsi import RSIStrategy
 
 STRATEGIES = {
     "breakout": BreakoutStrategy,
+    "dual_mom": DualMomentumStrategy,
     "ibs": IBSStrategy,
     "macd": MACDStrategy,
     "rsi": RSIStrategy,
@@ -14,6 +16,7 @@ STRATEGIES = {
 
 __all__ = [
     "BreakoutStrategy",
+    "DualMomentumStrategy",
     "IBSStrategy",
     "MACDStrategy",
     "RSIStrategy",

--- a/src/strategies/dual_mom.py
+++ b/src/strategies/dual_mom.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from typing import Any, Iterable
+
+import pandas as pd
+
+from .base import Strategy as BaseStrategy
+
+
+class DualMomentumStrategy(BaseStrategy):
+    """Simple dual momentum ETF rotation strategy."""
+
+    def __init__(
+        self, universe: Iterable[str], lookback_weeks: int = 26, top_k: int = 1
+    ) -> None:
+        self.universe = list(universe)
+        self.lookback_weeks = lookback_weeks
+        self.top_k = top_k
+        self._close_history: dict[str, pd.Series[float]] = {}
+        self._current_symbol: str | None = None
+        super().__init__(
+            universe=self.universe, lookback_weeks=lookback_weeks, top_k=top_k
+        )
+
+    def reset(self) -> None:
+        super().reset()
+        self._close_history = {t: pd.Series(dtype=float) for t in self.universe}
+        self._current_symbol = None
+
+    @staticmethod
+    def _is_month_end(ts: pd.Timestamp) -> bool:
+        return (ts + pd.Timedelta(days=1)).month != ts.month
+
+    def next_bar(self, bar: pd.Series[Any]) -> str:
+        if not isinstance(bar.name, pd.Timestamp):
+            raise ValueError(
+                "Bar index must be a pd.Timestamp for DualMomentum strategy"
+            )
+        ts = bar.name
+        for ticker in self.universe:
+            series = self._close_history.setdefault(ticker, pd.Series(dtype=float))
+            series.at[ts] = float(bar[ticker])
+
+        signal = "HOLD"
+        if self._is_month_end(ts):
+            weekly = {
+                t: series.resample("W-FRI").last()
+                for t, series in self._close_history.items()
+            }
+            trailing: dict[str, float] = {}
+            for t, series in weekly.items():
+                if len(series) < self.lookback_weeks + 1:
+                    trailing[t] = float("-inf")
+                else:
+                    start = float(series.iloc[-self.lookback_weeks - 1])
+                    end = float(series.iloc[-1])
+                    trailing[t] = (end - start) / start
+            ranked = sorted(trailing, key=lambda t: trailing[t], reverse=True)
+            winners = [t for t in ranked[: self.top_k] if trailing[t] > 0]
+            new_symbol = winners[0] if winners else None
+            if new_symbol is None:
+                if self._current_symbol is not None:
+                    signal = f"SELL:{self._current_symbol}"
+                    self._current_symbol = None
+            elif new_symbol != self._current_symbol:
+                signal = f"BUY:{new_symbol}"
+                self._current_symbol = new_symbol
+        return signal

--- a/tests/test_dual_mom.py
+++ b/tests/test_dual_mom.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from engine import Backtester  # noqa: E402
+from strategies.dual_mom import DualMomentumStrategy  # noqa: E402
+
+
+def test_dual_mom_signals() -> None:
+    index = pd.date_range("2023-01-01", periods=90, freq="D")
+    data = pd.DataFrame({
+        "AAA": range(90),
+        "BBB": range(90, 0, -1)
+    }, index=index)
+
+    strategy = DualMomentumStrategy(["AAA", "BBB"], lookback_weeks=1)
+    signals = [strategy.next_bar(row) for _, row in data.iterrows()]
+
+    jan_end = pd.Timestamp("2023-01-31")
+    assert signals[index.get_loc(jan_end)] == "BUY:AAA"
+
+
+def test_backtester_multi_asset() -> None:
+    index = pd.date_range("2023-01-01", periods=40, freq="D")
+    data = pd.DataFrame({
+        "AAA": range(40),
+        "BBB": range(40, 0, -1)
+    }, index=index)
+    strategy = DualMomentumStrategy(["AAA", "BBB"], lookback_weeks=1)
+    bt = Backtester(strategy, data)
+    results = bt.run()
+    assert len(results) == len(data)
+    assert any(t[0] == "BUY" for t in bt.trades)


### PR DESCRIPTION
## Summary
- add a dual momentum ETF rotation strategy
- extend Backtester to support ticker‐tagged signals
- expose `DualMomentumStrategy` via the strategies package
- test dual momentum logic and multi-asset Backtester

## Testing
- `ruff check .`
- `mypy`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862f36f435083239e5bcdb23fc696ed