### PR TITLE
Improve tests for metrics and MACD

### DIFF
--- a/tests/test_macd.py
+++ b/tests/test_macd.py
@@ -4,18 +4,35 @@ import sys
 from pathlib import Path
 
 import pandas as pd
+import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 
 from strategies.macd import MACDStrategy  # noqa: E402
 
 
-def test_macd_strategy_signals() -> None:
+def test_macd_strategy_basic_signals() -> None:
     index = pd.date_range("2023-01-02", periods=20, freq="B")
     closes = [1] * 5 + [10] * 5 + [5] * 5 + [15] * 5
     data = pd.DataFrame({"close": closes}, index=index)
     strategy = MACDStrategy(fast=2, slow=3, signal=2)
-
     signals = [strategy.next_bar(row) for _, row in data.iterrows()]
-
     assert "BUY" in signals and "SELL" in signals
+
+
+def test_macd_invalid_index() -> None:
+    strategy = MACDStrategy()
+    bar = pd.Series({"close": 1.0}, name=0)
+    with pytest.raises(ValueError):
+        strategy.next_bar(bar)
+
+
+def test_macd_hold_initially() -> None:
+    index = pd.date_range("2023-01-02", periods=2, freq="B")
+    closes = [1, 2]
+    strategy = MACDStrategy(fast=2, slow=3, signal=2)
+    signals = [
+        strategy.next_bar(pd.Series({"close": c}, name=i))
+        for i, c in zip(index, closes)
+    ]
+    assert signals[0] == "HOLD"

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from metrics import cagr, max_drawdown, sharpe_ratio  # noqa: E402
+
+
+def test_cagr_basic() -> None:
+    equity = pd.Series([1.0, 16.0])
+    start = "2020-01-01"
+    end = "2022-01-01"
+    rate = cagr(equity, start, end)
+    years = (pd.Timestamp(end) - pd.Timestamp(start)).days / 365.25
+    expected = 16.0 ** (1 / years) - 1
+    assert rate == pytest.approx(expected)
+
+
+def test_cagr_zero_years() -> None:
+    assert cagr(pd.Series([1.0]), "2020-01-01", "2020-01-01") == 0.0
+
+
+def test_sharpe_ratio_basic() -> None:
+    rets = pd.Series([0.1, 0.2, -0.1])
+    ratio = sharpe_ratio(rets)
+    assert ratio > 0
+
+
+def test_sharpe_ratio_edge_cases() -> None:
+    assert sharpe_ratio(pd.Series(dtype=float)) == 0.0
+    assert sharpe_ratio(pd.Series([0.05, 0.05])) == 0.0
+
+
+def test_max_drawdown() -> None:
+    drawdown = pd.Series([0.0, -0.1, -0.05])
+    assert max_drawdown(drawdown) == -0.1
+    assert max_drawdown(pd.Series(dtype=float)) == 0.0


### PR DESCRIPTION
## Summary
- add comprehensive tests for `metrics.py`
- enhance MACD strategy tests with error and hold checks

## Testing
- `ruff check .`
- `mypy`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862f42d054483239594be62fc47b795