### PR TITLE
Add Bollinger Band mean-reversion strategy

### DIFF
--- a/src/strategies/__init__.py
+++ b/src/strategies/__init__.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from .bollinger import BollingerStrategy
 from .breakout import BreakoutStrategy
 from .dual_mom import DualMomentumStrategy
 from .ibs import IBSStrategy
@@ -11,6 +12,7 @@ STRATEGIES = {
     "dual_mom": DualMomentumStrategy,
     "ibs": IBSStrategy,
     "macd": MACDStrategy,
+    "boll": BollingerStrategy,
     "rsi": RSIStrategy,
 }
 
@@ -19,6 +21,7 @@ __all__ = [
     "DualMomentumStrategy",
     "IBSStrategy",
     "MACDStrategy",
+    "BollingerStrategy",
     "RSIStrategy",
     "STRATEGIES",
 ]

--- a/src/strategies/bollinger.py
+++ b/src/strategies/bollinger.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pandas as pd
+
+from .base import Strategy as BaseStrategy
+
+
+class BollingerStrategy(BaseStrategy):
+    """Weekly Bollinger Band mean-reversion strategy."""
+
+    def __init__(self, length: int = 20, dev: float = 2.0) -> None:
+        super().__init__(length=length, dev=dev)
+        self.length = length
+        self.dev = dev
+        self._close_history = pd.Series(dtype=float)
+
+    def reset(self) -> None:
+        super().reset()
+        self._close_history = pd.Series(dtype=float)
+
+    def next_bar(self, bar: pd.Series[Any]) -> str:
+        if not isinstance(bar.name, pd.Timestamp):
+            raise ValueError(
+                "Bar index must be a pd.Timestamp for Bollinger strategy"
+            )
+        close = float(bar["close"])
+        self._close_history.at[bar.name] = close
+
+        weekly_close = self._close_history.resample("W-FRI").last()
+        ma = weekly_close.rolling(self.length).mean()
+        std = weekly_close.rolling(self.length).std()
+        lower_band = ma - self.dev * std
+
+        last_close = float(weekly_close.iloc[-1])
+        lb = lower_band.iloc[-1]
+        mid = ma.iloc[-1]
+
+        if pd.isna(lb) or pd.isna(mid):
+            return "HOLD"
+
+        if last_close < float(lb):
+            return "BUY"
+        if last_close >= float(mid):
+            return "SELL"
+        return "HOLD"

--- a/tests/test_bollinger.py
+++ b/tests/test_bollinger.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from strategies.bollinger import BollingerStrategy  # noqa: E402
+
+
+def test_bollinger_strategy_signals() -> None:
+    index = pd.date_range("2023-01-02", periods=20, freq="B")
+    closes = [100] * 5 + [102] * 5 + [90] * 5 + [100] * 5
+    data = pd.DataFrame({"close": closes}, index=index)
+
+    strategy = BollingerStrategy(length=2, dev=0.5)
+    signals = [strategy.next_bar(row) for _, row in data.iterrows()]
+
+    assert "BUY" in signals and "SELL" in signals


### PR DESCRIPTION
## Summary
- implement `BollingerStrategy` for weekly Bollinger Band signals
- register the strategy as `"boll"`
- test the Bollinger mean-reversion logic

## Testing
- `ruff check .`
- `mypy`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862f655b8888323a0105d8a64668e35