### PR TITLE
Add formatter and pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,21 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 23.7.0
+    hooks:
+      - id: black
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.4.4
+    hooks:
+      - id: ruff
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.8.0
+    hooks:
+      - id: mypy
+        additional_dependencies: [pandas-stubs]
+  - repo: local
+    hooks:
+      - id: pytest
+        name: pytest
+        entry: pytest -q
+        language: system
+        pass_filenames: false

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # MarketMind
 
 This repository is a template for a modern Python project. It includes linting with [Ruff](https://docs.astral.sh/ruff/), type checking with [mypy](https://mypy-lang.org/), and testing with [pytest](https://docs.pytest.org/).
+Code is formatted with [Black](https://black.readthedocs.io/) and these checks run automatically via [pre-commit](https://pre-commit.com/).
 
 Use this setup as a starting point for new projects that require a light-weight but strict development workflow.
 
@@ -10,6 +11,12 @@ Install the dependencies first:
 
 ```bash
 pip install -r requirements-dev.txt
+```
+
+Set up the pre-commit hooks after installing the requirements:
+
+```bash
+pre-commit install
 ```
 
 Run the helper scripts by pointing `PYTHONPATH` at the `src` directory:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,8 +27,12 @@ mypy_path = "src"
 
 [tool.coverage.run]
 branch = true
-source = ["marketmind"]
+source = ["src"]
 
 [tool.coverage.report]
 show_missing = true
 skip_covered = true
+
+[tool.black]
+target-version = ["py311"]
+line-length = 88

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,3 +7,5 @@ pandas-stubs
 pyarrow
 coverage
 pytest-cov
+black
+pre-commit


### PR DESCRIPTION
## Summary
- add pre-commit configuration
- configure Black in pyproject
- include black and pre-commit in dev requirements
- document pre-commit usage
- fix pre-commit pytest hook and coverage path

## Testing
- `ruff check .`
- `mypy src`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6862f46112a88323a05f6a5bb8a2a06d