### PR TITLE
Add CLI usage docs and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,29 @@ PYTHONPATH=./src python scripts/backtest.py ...
 PYTHONPATH=./src python scripts/signal.py ...
 ```
 
+For example, run a simple back-test of the RSI strategy on AAPL:
+
+```bash
+PYTHONPATH=./src python scripts/backtest.py \
+  --strategy rsi --ticker AAPL --start 2020-01-01 --end 2021-01-01 \
+  --params '{"rsi_buy": 30, "rsi_sell": 70}'
+```
+
+To sweep parameter combinations, pass lists in `--params` and add `--sweep`:
+
+```bash
+PYTHONPATH=./src python scripts/backtest.py \
+  --strategy rsi --ticker AAPL --start 2020-01-01 --end 2021-01-01 \
+  --params '{"rsi_buy": [20, 30], "rsi_sell": [70, 80]}' --sweep
+```
+
+You can print the most recent signal for a ticker with:
+
+```bash
+PYTHONPATH=./src python scripts/signal.py \
+  --strategy rsi --ticker AAPL --lookback 365
+```
+
 ## Streamlit UI
 
 Run the interactive web app locally:

--- a/tests/test_cli_scripts.py
+++ b/tests/test_cli_scripts.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+import pytest
+
+project_root = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(project_root / "src"))
+sys.path.insert(0, str(project_root))
+
+from scripts import backtest, signal  # noqa: E402
+
+
+def test_backtest_main(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    def fake_get_history(*args: str, **kwargs: str) -> pd.DataFrame:
+        index = pd.date_range("2020-01-01", periods=3, freq="D")
+        return pd.DataFrame({"close": [1.0, 1.1, 1.2]}, index=index)
+
+    monkeypatch.setattr(backtest.DataDownloader, "get_history", fake_get_history)
+
+    class DummyStrategy:
+        def reset(self) -> None:
+            pass
+
+        def next_bar(self, bar: pd.Series[Any]) -> str:  # type: ignore[override]
+            return "HOLD"
+
+    monkeypatch.setattr(
+        backtest,
+        "load_strategy",
+        lambda *args, **kwargs: DummyStrategy(),
+    )
+    monkeypatch.chdir(tmp_path)
+
+    argv = [
+        "backtest.py",
+        "--strategy",
+        "rsi",
+        "--ticker",
+        "TEST",
+        "--start",
+        "2020-01-01",
+        "--end",
+        "2020-01-04",
+    ]
+    monkeypatch.setattr(sys, "argv", argv)
+
+    backtest.main()
+    out = capsys.readouterr().out
+    assert "strategy" in out.lower()
+
+    result_file = tmp_path / "results" / "rsi_99914b93_TEST.csv"
+    assert result_file.exists()
+
+
+def test_signal_main(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    def fake_get_history(*args: str, **kwargs: str) -> pd.DataFrame:
+        index = pd.date_range("2020-01-01", periods=5, freq="D")
+        return pd.DataFrame({"close": [1, 2, 3, 4, 5]}, index=index)
+
+    monkeypatch.setattr(signal.DataDownloader, "get_history", fake_get_history)
+
+    class DummyStrategy:
+        def reset(self) -> None:
+            pass
+
+        def next_bar(self, bar: pd.Series[Any]) -> str:  # type: ignore[override]
+            return "HOLD"
+
+    monkeypatch.setattr(
+        signal,
+        "load_strategy",
+        lambda *args, **kwargs: DummyStrategy(),
+    )
+
+    argv = [
+        "signal.py",
+        "--strategy",
+        "rsi",
+        "--ticker",
+        "TEST",
+        "--lookback",
+        "5",
+    ]
+    monkeypatch.setattr(sys, "argv", argv)
+
+    signal.main()
+    out = capsys.readouterr().out.strip()
+    assert out in {"BUY", "SELL", "HOLD"}
+


### PR DESCRIPTION
## Summary
- document detailed examples of running CLI scripts
- add tests covering the CLI modules

## Testing
- `ruff check .`
- `mypy`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6863010ae4648323bbf39515f6884dff