### PR TITLE
Add auto_adjust to yfinance download

### DIFF
--- a/src/data.py
+++ b/src/data.py
@@ -29,7 +29,9 @@ class DataDownloader:
         if cache_file.exists():
             df = pd.read_parquet(cache_file)
         else:
-            df = yf.download(ticker, start=start, end=end, progress=False)
+            df = yf.download(
+                ticker, start=start, end=end, progress=False, auto_adjust=False
+            )
             df.to_parquet(cache_file)
         df.index.name = "date"
         df = df.loc[pd.Timestamp(start) : pd.Timestamp(end)]


### PR DESCRIPTION
## Summary
- explicitly set `auto_adjust=False` when downloading data with yfinance

## Testing
- `ruff check src/data.py`
- `mypy`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686305e674c48323b8e19986dbdc0c72