### PR TITLE
Use strategy registry in CLI scripts

### DIFF
--- a/scripts/backtest.py
+++ b/scripts/backtest.py
@@ -5,7 +5,6 @@ import hashlib
 import itertools
 import json
 import sys
-from importlib import import_module
 from pathlib import Path
 from typing import Any, cast
 
@@ -38,9 +37,10 @@ def generate_param_grid(params: dict[str, Any]) -> list[dict[str, Any]]:
 
 
 def load_strategy(name: str, params: dict[str, float]) -> Strategy:
-    module = import_module(f"strategies.{name}")
-    cls = cast(type[Strategy], getattr(module, "Strategy"))
-    return cls(**params)
+    cls = STRATEGIES.get(name)
+    if cls is None:
+        raise ValueError(f"Unknown strategy: {name}")
+    return cast(type[Strategy], cls)(**params)
 
 
 def main() -> None:

--- a/scripts/signal.py
+++ b/scripts/signal.py
@@ -4,19 +4,20 @@ import argparse
 import signal as _signal
 import sys
 from datetime import datetime, timedelta
-from importlib import import_module
 from pathlib import Path
 
 sys.modules["signal"] = _signal
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 
 from data import DataDownloader  # noqa: E402
+from strategies import STRATEGIES  # noqa: E402
 from strategies.base import Strategy  # noqa: E402
 
 
 def load_strategy(name: str) -> Strategy:
-    module = import_module(f"strategies.{name}")
-    cls = getattr(module, "Strategy")
+    cls = STRATEGIES.get(name)
+    if cls is None:
+        raise ValueError(f"Unknown strategy: {name}")
     return cls()
 
 

--- a/tests/test_cli_scripts.py
+++ b/tests/test_cli_scripts.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import sys
 from pathlib import Path
-from typing import Any
 
 import pandas as pd
 import pytest
@@ -25,18 +24,6 @@ def test_backtest_main(
 
     monkeypatch.setattr(backtest.DataDownloader, "get_history", fake_get_history)
 
-    class DummyStrategy:
-        def reset(self) -> None:
-            pass
-
-        def next_bar(self, bar: pd.Series[Any]) -> str:  # type: ignore[override]
-            return "HOLD"
-
-    monkeypatch.setattr(
-        backtest,
-        "load_strategy",
-        lambda *args, **kwargs: DummyStrategy(),
-    )
     monkeypatch.chdir(tmp_path)
 
     argv = [
@@ -69,19 +56,6 @@ def test_signal_main(
         return pd.DataFrame({"close": [1, 2, 3, 4, 5]}, index=index)
 
     monkeypatch.setattr(signal.DataDownloader, "get_history", fake_get_history)
-
-    class DummyStrategy:
-        def reset(self) -> None:
-            pass
-
-        def next_bar(self, bar: pd.Series[Any]) -> str:  # type: ignore[override]
-            return "HOLD"
-
-    monkeypatch.setattr(
-        signal,
-        "load_strategy",
-        lambda *args, **kwargs: DummyStrategy(),
-    )
 
     argv = [
         "signal.py",


### PR DESCRIPTION
## Summary
- lookup strategies using `STRATEGIES` mapping in signal & backtest CLIs
- remove test mocking of strategy loader

## Testing
- `ruff check .`
- `mypy`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686305d712348323b5b5227828a7d865