### PR TITLE
Improve CLI strategy loading tests

### DIFF
--- a/src/strategies/bollinger.py
+++ b/src/strategies/bollinger.py
@@ -43,3 +43,6 @@ class BollingerStrategy(BaseStrategy):
         if last_close >= float(mid):
             return "SELL"
         return "HOLD"
+
+
+Strategy = BollingerStrategy

--- a/src/strategies/breakout.py
+++ b/src/strategies/breakout.py
@@ -60,3 +60,6 @@ class BreakoutStrategy(BaseStrategy):
                 self.position = 0
                 self._highest_close = None
         return signal
+
+
+Strategy = BreakoutStrategy

--- a/src/strategies/dual_mom.py
+++ b/src/strategies/dual_mom.py
@@ -66,3 +66,6 @@ class DualMomentumStrategy(BaseStrategy):
                 signal = f"BUY:{new_symbol}"
                 self._current_symbol = new_symbol
         return signal
+
+
+Strategy = DualMomentumStrategy

--- a/src/strategies/ibs.py
+++ b/src/strategies/ibs.py
@@ -31,3 +31,6 @@ class IBSStrategy(BaseStrategy):
         if ibs >= self.sell_thr:
             return "SELL"
         return "HOLD"
+
+
+Strategy = IBSStrategy

--- a/src/strategies/macd.py
+++ b/src/strategies/macd.py
@@ -46,3 +46,6 @@ class MACDStrategy(BaseStrategy):
         if prev_macd >= prev_signal and curr_macd < curr_signal:
             return "SELL"
         return "HOLD"
+
+
+Strategy = MACDStrategy

--- a/src/strategies/rsi.py
+++ b/src/strategies/rsi.py
@@ -58,3 +58,6 @@ class RSIStrategy(BaseStrategy):
         if rsi_value >= self.rsi_sell:
             return "SELL"
         return "HOLD"
+
+
+Strategy = RSIStrategy


### PR DESCRIPTION
## Summary
- ensure CLI tests rely on actual strategy loader functions
- export `Strategy` alias from each strategy module

## Testing
- `ruff check .`
- `mypy`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686305ea34cc83239afe339f991513f7