### PR TITLE
Handle empty downloads

### DIFF
--- a/src/data.py
+++ b/src/data.py
@@ -32,6 +32,8 @@ class DataDownloader:
             df = yf.download(
                 ticker, start=start, end=end, progress=False, auto_adjust=False
             )
+            if df.empty:
+                raise ValueError(f"No data returned for ticker '{ticker}'")
             df.to_parquet(cache_file)
         df.index.name = "date"
         df = df.loc[pd.Timestamp(start) : pd.Timestamp(end)]

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1,0 +1,19 @@
+import pandas as pd
+import pytest
+import yfinance as yf
+
+from data import DataDownloader
+
+
+def test_get_history_raises_on_empty(monkeypatch, tmp_path):
+    downloader = DataDownloader(cache_dir=tmp_path)
+
+    def fake_download(*args, **kwargs):
+        return pd.DataFrame()
+
+    monkeypatch.setattr(yf, "download", fake_download)
+
+    with pytest.raises(ValueError, match="No data returned for ticker 'NONE'"):
+        downloader.get_history("NONE", "2020-01-01", "2020-01-05")
+
+    assert not (tmp_path / "NONE.parquet").exists()


### PR DESCRIPTION
## Summary
- validate downloaded data in `DataDownloader.get_history`
- add regression test for empty download case

## Testing
- `ruff check .`
- `mypy src`
- `pytest -q --cov --cov-fail-under=90`


------
https://chatgpt.com/codex/tasks/task_e_68636c8d88788323b2f22da3b678505e