### PR TITLE
Add pandas-stubs to dev dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dev = [
     "coverage>=7",
     "black>=25",
     "pre-commit",
+    "pandas-stubs>=2.2",
 ]
 streamlit = [
     "streamlit>=1.46",


### PR DESCRIPTION
## Summary
- add `pandas-stubs>=2.2` at the end of `[project.optional-dependencies].dev`
- install dev dependencies
- run linting, typing, and tests

## Testing
- `ruff check .`
- `mypy`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68636ca856008323ab5ef137dec40699