### PR TITLE
refactor strategies to use HistoryStrategy

### DIFF
--- a/src/strategies/base.py
+++ b/src/strategies/base.py
@@ -22,3 +22,15 @@ class Strategy(ABC):
     def next_bar(self, bar: pd.Series[Any]) -> str:
         """Process the next market bar and return a trading signal."""
         raise NotImplementedError
+
+
+class HistoryStrategy(Strategy):
+    """Strategy base class that stores historical close prices."""
+
+    def __init__(self, **params: Any) -> None:
+        super().__init__(**params)
+        self._close_history = pd.Series(dtype=float)
+
+    def reset(self) -> None:
+        super().reset()
+        self._close_history = pd.Series(dtype=float)

--- a/src/strategies/bollinger.py
+++ b/src/strategies/bollinger.py
@@ -4,21 +4,18 @@ from typing import Any
 
 import pandas as pd
 
-from .base import Strategy as BaseStrategy
+from .base import HistoryStrategy
 
 
-class BollingerStrategy(BaseStrategy):
+class BollingerStrategy(HistoryStrategy):
     """Weekly Bollinger Band mean-reversion strategy."""
 
     def __init__(self, length: int = 20, dev: float = 2.0) -> None:
         super().__init__(length=length, dev=dev)
         self.length = length
         self.dev = dev
-        self._close_history = pd.Series(dtype=float)
 
-    def reset(self) -> None:
-        super().reset()
-        self._close_history = pd.Series(dtype=float)
+
 
     def next_bar(self, bar: pd.Series[Any]) -> str:
         if not isinstance(bar.name, pd.Timestamp):

--- a/src/strategies/breakout.py
+++ b/src/strategies/breakout.py
@@ -4,22 +4,20 @@ from typing import Any
 
 import pandas as pd
 
-from .base import Strategy as BaseStrategy
+from .base import HistoryStrategy
 
 
-class BreakoutStrategy(BaseStrategy):
+class BreakoutStrategy(HistoryStrategy):
     """52-week high breakout momentum strategy."""
 
     def __init__(self, lookback_weeks: int = 52, stop_pct: float = 0.08) -> None:
         super().__init__(lookback_weeks=lookback_weeks, stop_pct=stop_pct)
         self.lookback_weeks = lookback_weeks
         self.stop_pct = stop_pct
-        self._close_history = pd.Series(dtype=float)
         self._highest_close: float | None = None
 
     def reset(self) -> None:
         super().reset()
-        self._close_history = pd.Series(dtype=float)
         self._highest_close = None
 
     def next_bar(self, bar: pd.Series[Any]) -> str:

--- a/src/strategies/macd.py
+++ b/src/strategies/macd.py
@@ -4,10 +4,10 @@ from typing import Any
 
 import pandas as pd
 
-from .base import Strategy as BaseStrategy
+from .base import HistoryStrategy
 
 
-class MACDStrategy(BaseStrategy):
+class MACDStrategy(HistoryStrategy):
     """Moving Average Convergence Divergence crossover strategy."""
 
     def __init__(self, fast: int = 12, slow: int = 26, signal: int = 9) -> None:
@@ -15,11 +15,6 @@ class MACDStrategy(BaseStrategy):
         self.fast = fast
         self.slow = slow
         self.signal = signal
-        self._close_history = pd.Series(dtype=float)
-
-    def reset(self) -> None:
-        super().reset()
-        self._close_history = pd.Series(dtype=float)
 
     def next_bar(self, bar: pd.Series[Any]) -> str:
         if not isinstance(bar.name, pd.Timestamp):

--- a/src/strategies/rsi.py
+++ b/src/strategies/rsi.py
@@ -4,7 +4,7 @@ from typing import Any
 
 import pandas as pd
 
-from .base import Strategy as BaseStrategy
+from .base import HistoryStrategy
 
 
 def wilder_rsi(series: pd.Series[float], length: int = 14) -> pd.Series[float]:
@@ -23,7 +23,7 @@ def wilder_rsi(series: pd.Series[float], length: int = 14) -> pd.Series[float]:
     return rsi
 
 
-class RSIStrategy(BaseStrategy):
+class RSIStrategy(HistoryStrategy):
     """Weekly RSI mean-reversion strategy."""
 
     def __init__(
@@ -33,11 +33,6 @@ class RSIStrategy(BaseStrategy):
         self.rsi_buy = rsi_buy
         self.rsi_sell = rsi_sell
         self.length = length
-        self._close_history = pd.Series(dtype=float)
-
-    def reset(self) -> None:
-        super().reset()
-        self._close_history = pd.Series(dtype=float)
 
     def next_bar(self, bar: pd.Series[Any]) -> str:
         """Return trading signal based on weekly RSI."""


### PR DESCRIPTION
## Summary
- add `HistoryStrategy` base class
- inherit from `HistoryStrategy` in RSI, MACD, Bollinger and Breakout strategies
- remove duplicated history tracking logic

## Testing
- `ruff check`
- `mypy`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68636cbaf4c4832392fc6ed3fe393648