### PR TITLE
Add cognitive load monitor tools

### DIFF
--- a/.github/workflows/cognitive_monitor.yml
+++ b/.github/workflows/cognitive_monitor.yml
@@ -1,0 +1,26 @@
+name: Cognitive Monitor
+
+on:
+  schedule:
+    - cron: '0 * * * *'
+  workflow_dispatch:
+
+jobs:
+  monitor:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pyyaml
+      - name: Analyze cognitive load
+        run: |
+          python analyze_cognitive_load.py || true
+      - name: Fail on break file
+        run: |
+          if [ -f .you-need-a-break ]; then exit 1; fi

--- a/analyze_cognitive_load.py
+++ b/analyze_cognitive_load.py
@@ -1,0 +1,131 @@
+"""Analyze prompt logs and warn about possible overload."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from pathlib import Path
+import sys
+
+import yaml
+
+CONFIG_PATH = Path("tracker_config.yaml")
+DEFAULT_LOG_PATH = Path("logs/prompt_log.md")
+
+
+@dataclass
+class PromptEntry:
+    timestamp: datetime
+    complexity: float
+    quality: str
+
+
+def parse_logs(log_path: Path) -> list[PromptEntry]:
+    entries: list[PromptEntry] = []
+    if not log_path.exists():
+        return entries
+    text = log_path.read_text().splitlines()
+    current_time: datetime | None = None
+    current_data: dict[str, str | float] = {}
+    for line in text:
+        if line.startswith("## "):
+            if current_time is not None:
+                entries.append(
+                    PromptEntry(
+                        current_time,
+                        float(current_data.get("complexity_score", 0)),
+                        str(current_data.get("quality", "")),
+                    )
+                )
+            current_time = datetime.fromisoformat(line[3:])
+            current_data = {}
+        elif line.startswith("```"):
+            continue
+        elif ":" in line:
+            key, value = line.split(":", 1)
+            current_data[key.strip()] = value.strip()
+    if current_time is not None:
+        entries.append(
+            PromptEntry(
+                current_time,
+                float(current_data.get("complexity_score", 0)),
+                str(current_data.get("quality", "")),
+            )
+        )
+    return entries
+
+
+def load_config() -> dict[str, float | str]:
+    if CONFIG_PATH.exists():
+        data = yaml.safe_load(CONFIG_PATH.read_text())
+        if isinstance(data, dict):
+            return {str(k): v for k, v in data.items()}
+    return {}
+
+
+def analyze(entries: list[PromptEntry], config: dict[str, float | str]) -> bool:
+    now = datetime.utcnow()
+    one_hour = now - timedelta(hours=1)
+    six_hours = now - timedelta(hours=6)
+    day_start = datetime.utcnow().replace(hour=0, minute=0, second=0, microsecond=0)
+
+    recent_1h = [e for e in entries if e.timestamp > one_hour]
+    recent_6h = [e for e in entries if e.timestamp > six_hours]
+    today = [e for e in entries if e.timestamp > day_start]
+
+    max_prompts_hour = int(config.get("max_prompts_hour", 20))
+    max_complexity_avg = float(config.get("max_complexity_avg_hour", 0.6))
+    max_active_hours = float(config.get("max_active_hours_day", 8))
+    complex_threshold = float(config.get("complex_threshold", 0.7))
+
+    overload = False
+
+    if len(recent_1h) > max_prompts_hour:
+        print("High number of prompts in last hour")
+        overload = True
+
+    if recent_1h:
+        avg_complexity = sum(e.complexity for e in recent_1h) / len(recent_1h)
+        if avg_complexity > max_complexity_avg:
+            print("Average complexity high in last hour")
+            overload = True
+
+    low_quality_streak = 0
+    for e in reversed(entries):
+        if e.quality.lower() in {"low", ""}:
+            low_quality_streak += 1
+        else:
+            break
+    if low_quality_streak >= 3:
+        print("Multiple low quality prompts detected")
+        overload = True
+
+    if today:
+        start = min(e.timestamp for e in today)
+        end = max(e.timestamp for e in today)
+        active_hours = (end - start).seconds / 3600
+        if active_hours > max_active_hours:
+            print("Long active time today")
+            overload = True
+
+    complex_count = sum(1 for e in recent_6h if e.complexity > complex_threshold)
+    if complex_count > max_prompts_hour:
+        print("Many complex prompts recently")
+        overload = True
+
+    return overload
+
+
+def main() -> None:
+    config = load_config()
+    log_path = Path(sys.argv[1]) if len(sys.argv) > 1 else DEFAULT_LOG_PATH
+    entries = parse_logs(log_path)
+    overload = analyze(entries, config)
+    if overload:
+        Path(".you-need-a-break").touch()
+        print("Warning: cognitive load may be high")
+        sys.exit(1)
+    print("Cognitive load normal")
+
+
+if __name__ == "__main__":
+    main()

--- a/logs/prompt_log.md
+++ b/logs/prompt_log.md
@@ -1,0 +1,19 @@
+## 2025-07-01T16:42
+```yaml
+complexity_score: 0.72
+quality: medium
+tokens_estimate: 246
+session_id: 2025-07-01
+project: codex_framework
+file: agents/PlannerAgent.md
+```
+
+## 2025-07-01T17:00
+```yaml
+complexity_score: 0.55
+quality: high
+tokens_estimate: 150
+session_id: 2025-07-01
+project: codex_framework
+file: agents/CoderAgent.md
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dev = [
     "black>=25",
     "pre-commit",
     "pandas-stubs>=2.2",
+    "types-PyYAML>=6",
 ]
 streamlit = [
     "streamlit>=1.46",

--- a/tests/test_cognitive_monitor.py
+++ b/tests/test_cognitive_monitor.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+import track_prompt
+import analyze_cognitive_load
+
+
+def test_track_prompt_logging(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    log_file = tmp_path / "log.md"
+    argv = [
+        "track_prompt.py",
+        "--prompt",
+        "A simple test prompt",
+        "--session-id",
+        "test",
+        "--project",
+        "proj",
+        "--file",
+        "file.txt",
+        "--log",
+        str(log_file),
+    ]
+    monkeypatch.setattr(sys, "argv", argv)
+    track_prompt.main()
+    assert log_file.exists()
+    content = log_file.read_text()
+    assert "complexity_score" in content
+
+
+def test_analyze_cognitive_load(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    log_file = tmp_path / "log.md"
+    # create two entries to trigger no overload
+    log_file.write_text(
+        "## 2030-01-01T00:00\n"
+        "complexity_score: 0.1\n"
+        "quality: high\n"
+        "tokens_estimate: 5\n"
+    )
+    monkeypatch.chdir(tmp_path)
+    result = analyze_cognitive_load.analyze(
+        analyze_cognitive_load.parse_logs(log_file),
+        analyze_cognitive_load.load_config(),
+    )
+    assert result is False
+

--- a/track_prompt.py
+++ b/track_prompt.py
@@ -1,0 +1,108 @@
+"""CLI tool to log developer prompts and metadata."""
+from __future__ import annotations
+
+import argparse
+from datetime import datetime
+from pathlib import Path
+
+import yaml
+
+# simple heuristics for complexity
+CONJUNCTIONS = {"and", "or", "but", "so", "because", "though", "although", "however"}
+LOGIC_OPERATORS = {"&&", "||", "!", "==", "!=", ">", "<", ">=", "<="}
+
+DEFAULT_LOG_PATH = Path("logs/prompt_log.md")
+
+
+def estimate_tokens(text: str) -> int:
+    """Rough token estimate based on character count."""
+    return max(1, len(text) // 4)
+
+
+def compute_readability(text: str) -> float:
+    """Basic Flesch reading ease score."""
+    sentences = max(text.count("."), 1)
+    words = text.split()
+    syllables = sum(count_syllables(word) for word in words)
+    num_words = len(words) or 1
+    words_per_sentence = num_words / sentences
+    syllables_per_word = syllables / num_words
+    return 206.835 - 1.015 * words_per_sentence - 84.6 * syllables_per_word
+
+
+def count_syllables(word: str) -> int:
+    word = word.lower()
+    vowels = "aeiouy"
+    count = 0
+    prev_char_was_vowel = False
+    for char in word:
+        if char in vowels:
+            if not prev_char_was_vowel:
+                count += 1
+            prev_char_was_vowel = True
+        else:
+            prev_char_was_vowel = False
+    if word.endswith("e") and count > 1:
+        count -= 1
+    return count or 1
+
+
+def compute_complexity(text: str) -> float:
+    tokens = text.split()
+    token_count = len(tokens) or 1
+    conj = sum(1 for t in tokens if t.lower() in CONJUNCTIONS)
+    logic = sum(1 for t in tokens if t in LOGIC_OPERATORS)
+    return (conj + logic) / token_count
+
+
+def quality_from_readability(score: float) -> str:
+    if score >= 60:
+        return "high"
+    if score >= 40:
+        return "medium"
+    return "low"
+
+
+def append_log(log_path: Path, entry_time: datetime, data: dict[str, object]) -> None:
+    log_path.parent.mkdir(exist_ok=True)
+    if log_path.exists():
+        contents = log_path.read_text()
+    else:
+        contents = ""
+    with log_path.open("a") as f:
+        if contents and not contents.endswith("\n"):
+            f.write("\n")
+        f.write(f"## {entry_time.isoformat(timespec='minutes')}\n")
+        yaml.dump(data, f, default_flow_style=False, sort_keys=False)
+        f.write("\n")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--prompt", required=True, help="Prompt text")
+    parser.add_argument("--session-id", required=True)
+    parser.add_argument("--project", default="unknown")
+    parser.add_argument("--file", default="unknown")
+    parser.add_argument("--log", default=str(DEFAULT_LOG_PATH), help="Log file path")
+    args = parser.parse_args()
+
+    complexity = compute_complexity(args.prompt)
+    readability = compute_readability(args.prompt)
+    tokens = estimate_tokens(args.prompt)
+    quality = quality_from_readability(readability)
+
+    data = {
+        "complexity_score": round(complexity, 2),
+        "quality": quality,
+        "tokens_estimate": tokens,
+        "session_id": args.session_id,
+        "project": args.project,
+        "file": args.file,
+    }
+
+    log_path = Path(args.log)
+    append_log(log_path, datetime.utcnow(), data)
+
+
+if __name__ == "__main__":
+    main()

--- a/tracker_config.yaml
+++ b/tracker_config.yaml
@@ -1,0 +1,5 @@
+max_prompts_hour: 20
+max_complexity_avg_hour: 0.6
+min_quality: medium
+max_active_hours_day: 8
+complex_threshold: 0.7


### PR DESCRIPTION
## Summary
- add CLI tool `track_prompt.py` for prompt logging
- create script `analyze_cognitive_load.py` for log analysis
- store sample entries in `logs/prompt_log.md`
- add thresholds in `tracker_config.yaml`
- run analyzer hourly with workflow
- include tests for new scripts
- add `types-PyYAML` to dev dependencies

## Testing
- `ruff check .`
- `mypy src track_prompt.py analyze_cognitive_load.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863b3e489f88323870d24a7c75aa124