### PR TITLE
Fix dual momentum via multi-ticker downloads

### DIFF
--- a/tests/test_framework.py
+++ b/tests/test_framework.py
@@ -7,6 +7,9 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 
 from typing import Any
 
+import pytest
+import yfinance as yf
+
 import pandas as pd
 
 from data import DataDownloader
@@ -21,6 +24,24 @@ def test_downloader_caches(tmp_path: Path) -> None:
     assert (tmp_path / "SPY.parquet").exists()
     df2 = downloader.get_history("SPY", "2020-01-01", "2020-01-10")
     assert len(df) == len(df2)
+
+
+def test_downloader_multi_ticker(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    downloader = DataDownloader(cache_dir=tmp_path)
+
+    def fake_download(*args: Any, **kwargs: Any) -> pd.DataFrame:
+        index = pd.date_range("2020-01-01", periods=3, freq="D")
+        arrays = [("Close", "AAA"), ("Close", "BBB")]
+        cols = pd.MultiIndex.from_tuples(arrays, names=["Price", "Ticker"])
+        return pd.DataFrame([[1, 2], [2, 1], [3, 0]], index=index, columns=cols)
+
+    monkeypatch.setattr(yf, "download", fake_download)
+
+    df = downloader.get_history(["AAA", "BBB"], "2020-01-01", "2020-01-04")
+    assert list(df.columns) == ["AAA", "BBB"]
+    assert len(df) == 3
 
 
 class DummyStrategy(Strategy):


### PR DESCRIPTION
## Summary
- support multiple tickers in `DataDownloader.get_history`
- add package initializer for scripts
- test multi-ticker downloads
- test dual momentum with downloader

## Testing
- `ruff check .`
- `mypy`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863eacc1cac8323a5bfccf9072d3a02