### PR TITLE
Add all-strategy signal mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,11 @@ You can print the most recent signal for a ticker with:
 PYTHONPATH=./src python scripts/signal.py \
   --strategy rsi --ticker AAPL --lookback 365
 ```
+To check the latest signal from every strategy:
+```bash
+PYTHONPATH=./src python scripts/signal.py \
+  --all --ticker AAPL --lookback 365
+```
 
 ## Streamlit UI
 

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -102,6 +102,25 @@ def latest_signal(
     )
     st.markdown(badge, unsafe_allow_html=True)
 
+
+def all_latest_signals(ticker: str, start: str, end: str) -> None:
+    try:
+        data = load_data(ticker, start, end)
+    except Exception as exc:  # noqa: BLE001
+        st.error(f"Data download failed: {exc}")
+        return
+
+    results = []
+    for name, cls in strategies.STRATEGIES.items():
+        strat = cls()
+        signal = "HOLD"
+        for _, row in data.iterrows():
+            signal = strat.next_bar(row)
+        results.append({"Strategy": name, "Signal": signal})
+
+    df = pd.DataFrame(results)
+    st.table(df)
+
 def main() -> None:
     strat_names = [n for n in strategies.__all__ if n != "STRATEGIES"]
     strat_name = st.sidebar.selectbox("Strategy", strat_names)
@@ -116,6 +135,8 @@ def main() -> None:
         run_backtest(strategy_cls, ticker, str(start), str(end), params)
     if st.sidebar.button("Latest Signal"):
         latest_signal(strategy_cls, ticker, str(start), str(end), params)
+    if st.sidebar.button("All Strategy Signals"):
+        all_latest_signals(ticker, str(start), str(end))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- allow `scripts/signal.py` to display signals for every strategy via `--all`
- show 'All Strategy Signals' in the Streamlit UI
- document the new CLI usage in README
- update CLI tests for new behaviour

## Testing
- `ruff check .`
- `mypy`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863f1b53ebc8323a9338b8f95ff2fe6