### PR TITLE
Refactor DataDownloader to per‑ticker downloads

### DIFF
--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -16,4 +16,5 @@ def test_get_history_raises_on_empty(monkeypatch, tmp_path):
     with pytest.raises(ValueError, match="No data returned for ticker 'NONE'"):
         downloader.get_history("NONE", "2020-01-01", "2020-01-05")
 
-    assert not (tmp_path / "NONE.parquet").exists()
+    cache_file = tmp_path / "NONE-2020-01-01-2020-01-05.parquet"
+    assert not cache_file.exists()


### PR DESCRIPTION
## Summary
- rewrite `DataDownloader.get_history` to fetch one symbol at a time
- cache normalized OHLCV data per ticker
- update unit tests for new column naming convention

## Testing
- `ruff check .`
- `mypy`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686402fc1ab0832383f90f36a92d9b87