### PR TITLE
Fix single ticker get_history bug

### DIFF
--- a/src/data.py
+++ b/src/data.py
@@ -61,4 +61,9 @@ class DataDownloader:
         combined = pd.concat(dfs, axis=1)
         combined.index.name = "date"
         combined = combined.sort_index()
+
+        if len(tickers) == 1:
+            prefix = f"{tickers[0].lower()}_"
+            combined = combined.rename(columns=lambda c: c.removeprefix(prefix))
+
         return combined.loc[pd.Timestamp(start) : pd.Timestamp(end)]

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -18,3 +18,35 @@ def test_get_history_raises_on_empty(monkeypatch, tmp_path):
 
     cache_file = tmp_path / "NONE-2020-01-01-2020-01-05.parquet"
     assert not cache_file.exists()
+
+
+def test_get_history_single_ticker_columns(monkeypatch, tmp_path):
+    downloader = DataDownloader(cache_dir=tmp_path)
+
+    index = pd.date_range("2020-01-01", periods=2, freq="D")
+    df = pd.DataFrame(
+        {
+            "Open": [1, 2],
+            "High": [3, 4],
+            "Low": [1, 2],
+            "Close": [2, 3],
+            "Adj Close": [2, 3],
+            "Volume": [10, 20],
+        },
+        index=index,
+    )
+
+    def fake_download(*args, **kwargs):
+        return df
+
+    monkeypatch.setattr(yf, "download", fake_download)
+
+    result = downloader.get_history("AAPL", "2020-01-01", "2020-01-02")
+    assert list(result.columns) == [
+        "open",
+        "high",
+        "low",
+        "close",
+        "adj_close",
+        "volume",
+    ]


### PR DESCRIPTION
## Summary
- strip ticker prefix when requesting a single ticker in `DataDownloader.get_history`
- add regression test covering single-ticker column names

## Testing
- `ruff check .`
- `mypy`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686407eb7a34832396896970b598fda7