### PR TITLE
Add fetch_data utility with CLI and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,3 +62,12 @@ Run the interactive web app locally:
 pip install -e .[streamlit]
 streamlit run streamlit_app.py
 ```
+
+## Quick data pull
+
+Fetch price history from the command line:
+
+```bash
+python scripts/fetch.py --tickers "SPY,IDTL" --start 2020-01-01 --end 2020-01-10 \
+  --csv-out data
+```

--- a/fetch_data.py
+++ b/fetch_data.py
@@ -1,0 +1,66 @@
+"""Simple data fetch helper wrapping :class:`DataDownloader`."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+from typing import Iterable
+
+import pandas as pd
+
+from data import DataDownloader
+
+# Map of non-UCITS tickers to their UCITS equivalents
+_UCITS = {"SPY": "CSP1"}
+
+__all__ = ["fetch"]
+
+
+def fetch(
+    tickers: str | Iterable[str],
+    start: str = "2000-01-01",
+    end: str | None = None,
+    interval: str = "1d",
+    ucits_map: bool = True,
+) -> dict[str, pd.DataFrame]:
+    """Return historical OHLCV data for ``tickers``.
+
+    Args:
+        tickers: A ticker symbol or list of symbols.
+        start: ISO formatted start date.
+        end: ISO formatted end date. Defaults to today when ``None``.
+        interval: Bar interval (unused, kept for API compatibility).
+        ucits_map: Map symbols to their UCITS equivalent when ``True``.
+
+    Returns:
+        Mapping of canonical ticker to :class:`pandas.DataFrame` with OHLCV data.
+    """
+    symbols = [tickers] if isinstance(tickers, str) else list(tickers)
+    if end is None:
+        end = datetime.utcnow().date().isoformat()
+
+    downloader = DataDownloader()
+    result: dict[str, pd.DataFrame] = {}
+    for sym in symbols:
+        remote = _UCITS.get(sym, sym) if ucits_map else sym
+        df = downloader.get_history(remote, start, end)
+        result[sym] = df
+    return result
+
+
+def _main() -> None:
+    import sys
+
+    args = sys.argv[1:]
+    if not args:
+        print("Usage: python -m fetch_data TICKER [TICKER...]")
+        raise SystemExit(1)
+    data = fetch(args)
+    for ticker, df in data.items():
+        out = Path(f"{ticker}.csv")
+        df.to_csv(out)
+        print(f"Wrote {out}")
+
+
+if __name__ == "__main__":
+    _main()

--- a/scripts/fetch.py
+++ b/scripts/fetch.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from fetch_data import fetch  # noqa: E402
+
+
+def main() -> dict[str, pd.DataFrame]:
+    parser = argparse.ArgumentParser(description="Fetch historical data")
+    parser.add_argument("--tickers", required=True, help="Comma separated tickers")
+    parser.add_argument("--start", default="2000-01-01", help="Start date YYYY-MM-DD")
+    parser.add_argument("--end", help="End date YYYY-MM-DD")
+    parser.add_argument("--interval", default="1d", help="Bar interval")
+    parser.add_argument(
+        "--ucits-off",
+        action="store_true",
+        help="Disable UCITS mapping",
+    )
+    parser.add_argument("--csv-out", help="Directory to write CSV files")
+    parser.add_argument("--json", action="store_true", help="Print JSON to stdout")
+    args = parser.parse_args()
+
+    ticker_list = [t.strip() for t in args.tickers.split(",") if t.strip()]
+
+    data = fetch(
+        ticker_list,
+        start=args.start,
+        end=args.end,
+        interval=args.interval,
+        ucits_map=not args.ucits_off,
+    )
+
+    if args.csv_out:
+        out_dir = Path(args.csv_out)
+        out_dir.mkdir(parents=True, exist_ok=True)
+        for ticker, df in data.items():
+            df.to_csv(out_dir / f"{ticker}.csv")
+
+    if args.json:
+        serialised = {
+            t: df.reset_index()
+            .assign(date=lambda d: d["date"].astype(str))
+            .to_dict(orient="records")
+            for t, df in data.items()
+        }
+        print(json.dumps(serialised))
+
+    return data
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_fetch.py
+++ b/tests/test_fetch.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+project_root = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(project_root))
+sys.path.insert(0, str(project_root / "src"))
+
+import fetch_data  # noqa: E402
+from scripts import fetch as fetch_cli  # noqa: E402
+
+
+def _fake_history(*args: str, **kwargs: str) -> pd.DataFrame:
+    index = pd.date_range("2020-01-01", periods=2, freq="D")
+    index.name = "date"
+    return pd.DataFrame(
+        {
+            "open": [1, 2],
+            "high": [2, 3],
+            "low": [1, 1],
+            "close": [1, 2],
+            "adj_close": [1, 2],
+            "volume": [10, 20],
+        },
+        index=index,
+    )
+
+
+def test_fetch_function(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(fetch_data.DataDownloader, "get_history", _fake_history)
+    result = fetch_data.fetch(["SPY", "IDTL"], start="2020-01-01", end="2020-01-02")
+    assert set(result.keys()) == {"SPY", "IDTL"}
+    for df in result.values():
+        assert list(df.columns) == [
+            "open",
+            "high",
+            "low",
+            "close",
+            "adj_close",
+            "volume",
+        ]
+
+
+def test_cli_writes_csv(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(fetch_data.DataDownloader, "get_history", _fake_history)
+
+    argv = [
+        "fetch.py",
+        "--tickers",
+        "SPY,IDTL",
+        "--start",
+        "2020-01-01",
+        "--end",
+        "2020-01-02",
+        "--csv-out",
+        str(tmp_path),
+        "--json",
+    ]
+    monkeypatch.setattr(sys, "argv", argv)
+
+    data = fetch_cli.main()
+    assert set(data.keys()) == {"SPY", "IDTL"}
+    assert (tmp_path / "SPY.csv").exists()
+    assert (tmp_path / "IDTL.csv").exists()


### PR DESCRIPTION
## Summary
- implement `fetch` helper wrapping `DataDownloader`
- add CLI script `scripts/fetch.py`
- test new functionality and update README

## Testing
- `ruff check .`
- `mypy src`
- `pytest --cov`


------
https://chatgpt.com/codex/tasks/task_e_6864ea7cebfc8323901d10eec0adb3aa