### PR TITLE
Add EU-friendly Reddit strategies

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,3 +70,7 @@ This project follows strict linting and typing rules. The main tools are:
 All code must pass Ruff, mypy, and pytest locally before being committed. Continuous integration runs these tools on every push and pull request to `main`.
 
 Consider the instructions in SYSTEM.md!
+
+## Project Index
+- [README](README.md)
+- [Strategy Descriptions](docs/strategies.md)

--- a/README.md
+++ b/README.md
@@ -71,3 +71,15 @@ Fetch price history from the command line:
 python scripts/fetch.py --tickers "SPY,IDTL" --start 2020-01-01 --end 2020-01-10 \
   --csv-out data
 ```
+
+## EU-friendly Reddit strategies
+
+The following UCITS ETFs are used to replicate popular leveraged Reddit portfolios in the EEA.
+
+| US Ticker | UCITS Ticker |
+|-----------|--------------|
+| UPRO | 3USL |
+| TMF  | 3TYL |
+| TQQQ | QQQ3 |
+| SPY  | CSPX |
+| TLT  | IDTL |

--- a/docs/strategies.md
+++ b/docs/strategies.md
@@ -1,0 +1,13 @@
+# Strategies
+
+## LeveragedTrendStrategy
+Long the Xtrackers S&P 500 2× (ISIN LU0411078552) when the close is above its 200‑day simple moving average. Otherwise stay in cash. Parameter `sma_len` controls the SMA length in days.
+
+## HFEA55Strategy
+Allocates 55 % to WisdomTree S&P 500 3× (ISIN IE00B7KQZF44, ticker `3USL`) and 45 % to WisdomTree 10‑Yr Treasury 3× (ISIN IE00BKT09032, ticker `3TYL`). The portfolio is rebalanced at each month end. Parameter `rebalance_days` sets the minimum business days between rebalances.
+
+## CoveredCallMedianStrategy
+Trades the Global X S&P 500 Covered Call UCITS ETF (ISIN IE00BKT6Q882, ticker `XYLU`) using a 60‑day rolling median. Buy when price is below `(1 − band)` times the median and sell when above `(1 + band)` times the median. Parameter `band` is expressed as a percent.
+
+## EndOfMonthBondPopStrategy
+Holds the iShares $ Treasury 20+ yr UCITS ETF (ISIN IE00B1FZS806, ticker `IDTL`) only for the final `hold_days` trading days of each calendar month.

--- a/scripts/signal.py
+++ b/scripts/signal.py
@@ -10,9 +10,15 @@ sys.modules["signal"] = _signal
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 
 from data import DataDownloader  # noqa: E402
-from strategies import STRATEGIES  # noqa: E402
+import strategies  # noqa: E402
 from strategies.base import Strategy  # noqa: E402
 from typing import cast  # noqa: E402
+
+STRATEGIES = {
+    name.removesuffix("Strategy").lower(): getattr(strategies, name)
+    for name in strategies.__all__
+    if name != "STRATEGIES"
+}
 
 
 def load_strategy(name: str) -> Strategy:
@@ -58,7 +64,8 @@ def main() -> None:
         signal = "HOLD"
         for _, bar in data.iterrows():
             signal = strategy.next_bar(bar)
-        print(f"{name}: {signal}")
+        out = signal if isinstance(signal, str) else "N/A"
+        print(f"{name}: {out}")
 
 
 if __name__ == "__main__":

--- a/src/strategies/__init__.py
+++ b/src/strategies/__init__.py
@@ -6,22 +6,26 @@ from .dual_mom import DualMomentumStrategy
 from .ibs import IBSStrategy
 from .macd import MACDStrategy
 from .rsi import RSIStrategy
+from .leveragedtrend import LeveragedTrendStrategy
+from .hfea55 import HFEA55Strategy
+from .median_cc import CoveredCallMedianStrategy
+from .eom_bond import EndOfMonthBondPopStrategy
+
+_classes = [
+    BreakoutStrategy,
+    DualMomentumStrategy,
+    IBSStrategy,
+    MACDStrategy,
+    BollingerStrategy,
+    RSIStrategy,
+    LeveragedTrendStrategy,
+    HFEA55Strategy,
+    CoveredCallMedianStrategy,
+    EndOfMonthBondPopStrategy,
+]
 
 STRATEGIES = {
-    "breakout": BreakoutStrategy,
-    "dual_mom": DualMomentumStrategy,
-    "ibs": IBSStrategy,
-    "macd": MACDStrategy,
-    "boll": BollingerStrategy,
-    "rsi": RSIStrategy,
+    cls.__name__.removesuffix("Strategy").lower(): cls for cls in _classes
 }
 
-__all__ = [
-    "BreakoutStrategy",
-    "DualMomentumStrategy",
-    "IBSStrategy",
-    "MACDStrategy",
-    "BollingerStrategy",
-    "RSIStrategy",
-    "STRATEGIES",
-]
+__all__ = [cls.__name__ for cls in _classes] + ["STRATEGIES"]

--- a/src/strategies/base.py
+++ b/src/strategies/base.py
@@ -19,7 +19,7 @@ class Strategy(ABC):
         self.today: pd.Timestamp | None = None
 
     @abstractmethod
-    def next_bar(self, bar: pd.Series[Any]) -> str:
+    def next_bar(self, bar: pd.Series[Any]) -> str | dict[str, float]:
         """Process the next market bar and return a trading signal."""
         raise NotImplementedError
 

--- a/src/strategies/eom_bond.py
+++ b/src/strategies/eom_bond.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pandas as pd
+from pandas.tseries.offsets import BDay, BMonthEnd
+
+from .base import Strategy
+
+
+class EndOfMonthBondPopStrategy(Strategy):
+    """Hold a Treasury ETF only for the last ``hold_days`` of each month."""
+
+    def __init__(self, hold_days: int = 7) -> None:
+        super().__init__(hold_days=hold_days)
+        self.hold_days = hold_days
+
+    @staticmethod
+    def _in_window(ts: pd.Timestamp, hold_days: int) -> bool:
+        end = ts + BMonthEnd(0)
+        start = end - BDay(hold_days - 1)
+        return start <= ts <= end
+
+    def next_bar(self, bar: pd.Series[Any]) -> str:
+        if not isinstance(bar.name, pd.Timestamp):
+            raise ValueError(
+                "Bar index must be a pd.Timestamp for EndOfMonthBondPop strategy"
+            )
+        ts = bar.name
+        active = self._in_window(ts, self.hold_days)
+        if self.position == 0 and active:
+            self.position = 1
+            return "BUY"
+        if self.position == 1 and not active:
+            self.position = 0
+            return "SELL"
+        return "HOLD"

--- a/src/strategies/hfea55.py
+++ b/src/strategies/hfea55.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pandas as pd
+from pandas.tseries.offsets import BMonthEnd
+
+from .base import Strategy
+
+
+class HFEA55Strategy(Strategy):
+    """Hold 55% S&P 500 3× and 45% 10yr Treasury 3×, rebalanced monthly."""
+
+    def __init__(self, rebalance_days: int = 21) -> None:
+        super().__init__(rebalance_days=rebalance_days)
+        self.rebalance_days = rebalance_days
+        self._last_rebalance: pd.Timestamp | None = None
+
+    @staticmethod
+    def _is_month_end(ts: pd.Timestamp) -> bool:
+        return ts == (ts + BMonthEnd(0))
+
+    def next_bar(self, bar: pd.Series[Any]) -> dict[str, float] | str:
+        if not isinstance(bar.name, pd.Timestamp):
+            raise ValueError(
+                "Bar index must be a pd.Timestamp for HFEA55 strategy"
+            )
+        ts = bar.name
+        if self._last_rebalance is None:
+            self._last_rebalance = ts
+            return {"3USL": 0.55, "3TYL": 0.45}
+        if self._is_month_end(ts) and (
+            ts - self._last_rebalance
+        ).days >= self.rebalance_days:
+            self._last_rebalance = ts
+            return {"3USL": 0.55, "3TYL": 0.45}
+        return {}

--- a/src/strategies/leveragedtrend.py
+++ b/src/strategies/leveragedtrend.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pandas as pd
+
+from .base import HistoryStrategy
+
+
+class LeveragedTrendStrategy(HistoryStrategy):
+    """Simple trend-following strategy using a leveraged S&P 500 ETF."""
+
+    def __init__(self, sma_len: int = 200) -> None:
+        super().__init__(sma_len=sma_len)
+        self.sma_len = sma_len
+
+    def next_bar(self, bar: pd.Series[Any]) -> str:
+        if not isinstance(bar.name, pd.Timestamp):
+            raise ValueError(
+                "Bar index must be a pd.Timestamp for LeveragedTrend strategy"
+            )
+        close = float(bar["close"])
+        self._close_history.at[bar.name] = close
+
+        weeks = max(1, self.sma_len // 5)
+        weekly_close = self._close_history.resample("W-FRI").last()
+        sma = weekly_close.rolling(weeks).mean().iloc[-1]
+
+        if pd.isna(sma):
+            return "HOLD"
+
+        current = float(weekly_close.iloc[-1])
+        if self.position == 0 and current > float(sma):
+            self.position = 1
+            return "BUY"
+        if self.position == 1 and current <= float(sma):
+            self.position = 0
+            return "SELL"
+        return "HOLD"

--- a/src/strategies/median_cc.py
+++ b/src/strategies/median_cc.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pandas as pd
+
+from .base import HistoryStrategy
+
+
+class CoveredCallMedianStrategy(HistoryStrategy):
+    """Median-reversion strategy for a covered call ETF."""
+
+    def __init__(self, band: float = 0.01, median_len: int = 60) -> None:
+        super().__init__(band=band, median_len=median_len)
+        self.band = band / 100 if band >= 1 else band
+        self.median_len = median_len
+
+    def next_bar(self, bar: pd.Series[Any]) -> str:
+        if not isinstance(bar.name, pd.Timestamp):
+            raise ValueError(
+                "Bar index must be a pd.Timestamp for CoveredCallMedian strategy"
+            )
+        close = float(bar["close"])
+        self._close_history.at[bar.name] = close
+
+        med = self._close_history.rolling(self.median_len).median().iloc[-1]
+        if pd.isna(med):
+            return "HOLD"
+
+        lower = float(med) * (1 - self.band)
+        upper = float(med) * (1 + self.band)
+
+        if self.position == 0 and close <= lower:
+            self.position = 1
+            return "BUY"
+        if self.position == 1 and close >= upper:
+            self.position = 0
+            return "SELL"
+        return "HOLD"

--- a/tests/test_eom_bond.py
+++ b/tests/test_eom_bond.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from strategies.eom_bond import EndOfMonthBondPopStrategy  # noqa: E402
+
+
+def test_eom_bond_signals() -> None:
+    index = pd.date_range("2024-01-02", periods=40, freq="B")
+    closes = list(range(40))
+    data = pd.DataFrame({"close": closes}, index=index)
+
+    strat = EndOfMonthBondPopStrategy(hold_days=5)
+    signals = [strat.next_bar(row) for _, row in data.iterrows()]
+
+    assert "BUY" in signals and "SELL" in signals

--- a/tests/test_hfea55.py
+++ b/tests/test_hfea55.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from strategies.hfea55 import HFEA55Strategy  # noqa: E402
+
+
+def test_hfea55_weights() -> None:
+    index = pd.date_range("2024-01-02", periods=40, freq="B")
+    data = pd.DataFrame({"3USL": 100.0, "3TYL": 100.0}, index=index)
+
+    strat = HFEA55Strategy(rebalance_days=20)
+    signals = [strat.next_bar(row) for _, row in data.iterrows()]
+
+    assert any(isinstance(s, dict) and s for s in signals)

--- a/tests/test_leveragedtrend.py
+++ b/tests/test_leveragedtrend.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from strategies.leveragedtrend import LeveragedTrendStrategy  # noqa: E402
+
+
+def test_leveragedtrend_signals() -> None:
+    index = pd.date_range("2023-01-02", periods=260, freq="B")
+    prices = [100] * 220 + [110] * 20 + [90] * 20
+    data = pd.DataFrame({"close": prices}, index=index)
+
+    strat = LeveragedTrendStrategy(sma_len=200)
+    signals = [strat.next_bar(row) for _, row in data.iterrows()]
+
+    assert "BUY" in signals and "SELL" in signals

--- a/tests/test_median_cc.py
+++ b/tests/test_median_cc.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from strategies.median_cc import CoveredCallMedianStrategy  # noqa: E402
+
+
+def test_cc_median_signals() -> None:
+    index = pd.date_range("2024-01-02", periods=80, freq="B")
+    closes = [100] * 60 + [80] * 10 + [110] * 10
+    data = pd.DataFrame({"close": closes}, index=index)
+
+    strat = CoveredCallMedianStrategy(band=1.0)
+    signals = [strat.next_bar(row) for _, row in data.iterrows()]
+
+    assert "BUY" in signals and "SELL" in signals


### PR DESCRIPTION
## Summary
- implement four new strategy classes for EU ETFs
- support UCITS ticker mapping in DataDownloader
- extend Backtester with weight-based signals
- auto-discover strategies in scripts and add parameter grids
- document strategies and add tests

## Testing
- `ruff check .`
- `pytest --cov=src --cov-fail-under=90 -q`


------
https://chatgpt.com/codex/tasks/task_e_68650eb173f08323a3d49e2c213ce58f