### PR TITLE
Add mypy options and CI step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Run ruff
         run: ruff check .
       - name: Run mypy
-        run: mypy src
+        run: mypy --install-types --non-interactive --show-error-codes src
       - name: Run pytest
         run: pytest -q -m "not network" --cov=src --cov-report=xml --cov-fail-under=90
       - name: Upload coverage artifact

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,8 @@ testpaths = ["tests"]
 
 [tool.mypy]
 python_version = "3.11"
+show_error_codes = true
+warn_unused_configs = true
 strict = true
 files = ["src"]
 mypy_path = "src"


### PR DESCRIPTION
## Summary
- show error codes for mypy and check for unused config entries
- run mypy in CI with automatic stub installation and error codes

## Testing
- `ruff check .`
- `mypy --install-types --non-interactive --show-error-codes src`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865258ccc3c8323a7f8edb6c4bd7682