### PR TITLE
Move CLI scripts to project root

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,14 +22,14 @@ pre-commit install
 Run the helper scripts by pointing `PYTHONPATH` at the `src` directory:
 
 ```bash
-PYTHONPATH=./src python scripts/backtest.py ...
-PYTHONPATH=./src python scripts/signal.py ...
+PYTHONPATH=./src python backtest.py ...
+PYTHONPATH=./src python signal.py ...
 ```
 
 For example, run a simple back-test of the RSI strategy on AAPL:
 
 ```bash
-PYTHONPATH=./src python scripts/backtest.py \
+PYTHONPATH=./src python backtest.py \
   --strategy rsi --ticker AAPL --start 2020-01-01 --end 2021-01-01 \
   --params '{"rsi_buy": 30, "rsi_sell": 70}'
 ```
@@ -37,7 +37,7 @@ PYTHONPATH=./src python scripts/backtest.py \
 To sweep parameter combinations, pass lists in `--params` and add `--sweep`:
 
 ```bash
-PYTHONPATH=./src python scripts/backtest.py \
+PYTHONPATH=./src python backtest.py \
   --strategy rsi --ticker AAPL --start 2020-01-01 --end 2021-01-01 \
   --params '{"rsi_buy": [20, 30], "rsi_sell": [70, 80]}' --sweep
 ```
@@ -45,12 +45,12 @@ PYTHONPATH=./src python scripts/backtest.py \
 You can print the most recent signal for a ticker with:
 
 ```bash
-PYTHONPATH=./src python scripts/signal.py \
+PYTHONPATH=./src python signal.py \
   --strategy rsi --ticker AAPL --lookback 365
 ```
 To check the latest signal from every strategy:
 ```bash
-PYTHONPATH=./src python scripts/signal.py \
+PYTHONPATH=./src python signal.py \
   --all --ticker AAPL --lookback 365
 ```
 
@@ -68,7 +68,7 @@ streamlit run streamlit_app.py
 Fetch price history from the command line:
 
 ```bash
-python scripts/fetch.py --tickers "SPY,IDTL" --start 2020-01-01 --end 2020-01-10 \
+python fetch.py --tickers "SPY,IDTL" --start 2020-01-01 --end 2020-01-10 \
   --csv-out data
 ```
 

--- a/backtest.py
+++ b/backtest.py
@@ -8,7 +8,7 @@ import sys
 from pathlib import Path
 from typing import Any, cast
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+sys.path.insert(0, str(Path(__file__).resolve().parent / "src"))
 
 from data import DataDownloader
 from engine import Backtester

--- a/fetch.py
+++ b/fetch.py
@@ -7,8 +7,8 @@ from pathlib import Path
 
 import pandas as pd
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
-sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+sys.path.insert(0, str(Path(__file__).resolve().parent / "src"))
 
 from fetch_data import fetch  # noqa: E402
 

--- a/signal.py
+++ b/signal.py
@@ -7,16 +7,18 @@ from datetime import datetime, timedelta
 from pathlib import Path
 
 sys.modules["signal"] = _signal
-sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+sys.path.insert(0, str(Path(__file__).resolve().parent / "src"))
 
 from data import DataDownloader  # noqa: E402
 import strategies  # noqa: E402
 from strategies.base import Strategy  # noqa: E402
 from typing import cast  # noqa: E402
 
+_all_strategies: list[str] = cast(list[str], getattr(strategies, "__all__", []))
+
 STRATEGIES = {
     name.removesuffix("Strategy").lower(): getattr(strategies, name)
-    for name in strategies.__all__
+    for name in _all_strategies
     if name != "STRATEGIES"
 }
 
@@ -61,10 +63,10 @@ def main() -> None:
         except TypeError:
             print(f"{name}: N/A")
             continue
-        signal = "HOLD"
+        signal_value: str | dict[str, float] = "HOLD"
         for _, bar in data.iterrows():
-            signal = strategy.next_bar(bar)
-        out = signal if isinstance(signal, str) else "N/A"
+            signal_value = strategy.next_bar(bar)
+        out = signal_value if isinstance(signal_value, str) else "N/A"
         print(f"{name}: {out}")
 
 

--- a/tests/test_cli_scripts.py
+++ b/tests/test_cli_scripts.py
@@ -10,7 +10,15 @@ project_root = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(project_root / "src"))
 sys.path.insert(0, str(project_root))
 
-from scripts import backtest, signal  # noqa: E402
+import importlib.util  # noqa: E402
+
+import backtest  # noqa: E402
+
+signal_path = project_root / "signal.py"
+spec = importlib.util.spec_from_file_location("signal_cli", signal_path)
+assert spec and spec.loader
+signal_cli = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(signal_cli)
 
 
 def test_backtest_main(
@@ -62,7 +70,7 @@ def test_signal_main(
             index=index,
         )
 
-    monkeypatch.setattr(signal.DataDownloader, "get_history", fake_get_history)
+    monkeypatch.setattr(signal_cli.DataDownloader, "get_history", fake_get_history)
 
     argv = [
         "signal.py",
@@ -75,7 +83,7 @@ def test_signal_main(
     ]
     monkeypatch.setattr(sys, "argv", argv)
 
-    signal.main()
+    signal_cli.main()
     out = capsys.readouterr().out.strip()
     name, val = out.split(": ")
     assert name == "rsi"
@@ -97,7 +105,7 @@ def test_signal_main_all(
             index=index,
         )
 
-    monkeypatch.setattr(signal.DataDownloader, "get_history", fake_get_history)
+    monkeypatch.setattr(signal_cli.DataDownloader, "get_history", fake_get_history)
 
     argv = [
         "signal.py",
@@ -109,11 +117,11 @@ def test_signal_main_all(
     ]
     monkeypatch.setattr(sys, "argv", argv)
 
-    signal.main()
+    signal_cli.main()
     out_lines = capsys.readouterr().out.strip().splitlines()
-    assert len(out_lines) == len(signal.STRATEGIES)
+    assert len(out_lines) == len(signal_cli.STRATEGIES)
     for line in out_lines:
         name, val = line.split(": ")
-        assert name in signal.STRATEGIES
+        assert name in signal_cli.STRATEGIES
         assert val in {"BUY", "SELL", "HOLD", "N/A"}
 

--- a/tests/test_fetch.py
+++ b/tests/test_fetch.py
@@ -11,7 +11,7 @@ sys.path.insert(0, str(project_root))
 sys.path.insert(0, str(project_root / "src"))
 
 import fetch_data  # noqa: E402
-from scripts import fetch as fetch_cli  # noqa: E402
+import fetch as fetch_cli  # noqa: E402
 
 
 def _fake_history(*args: str, **kwargs: str) -> pd.DataFrame:

--- a/tests/test_param_grid.py
+++ b/tests/test_param_grid.py
@@ -7,7 +7,7 @@ project_root = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(project_root / "src"))
 sys.path.insert(0, str(project_root))
 
-from scripts.backtest import generate_param_grid  # noqa: E402
+from backtest import generate_param_grid  # noqa: E402
 
 
 def test_generate_param_grid() -> None:


### PR DESCRIPTION
## Summary
- move standalone scripts out of `scripts` package
- fix imports and test helpers for new locations
- adjust sys.path usage in scripts
- update README usage examples

## Testing
- `ruff check .`
- `mypy`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686528127bcc8323be2e29e05de4f03a