### PR TITLE
Update cognitive monitor trigger

### DIFF
--- a/.github/workflows/cognitive_monitor.yml
+++ b/.github/workflows/cognitive_monitor.yml
@@ -1,12 +1,13 @@
 name: Cognitive Monitor
 
 on:
-  schedule:
-    - cron: '0 * * * *'
-  workflow_dispatch:
+  pull_request:
+    types:
+      - closed
 
 jobs:
   monitor:
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
## Summary
- trigger the cognitive monitor workflow only when pull requests are merged

## Testing
- `ruff check .`
- `mypy --install-types --non-interactive --show-error-codes src`
- `pytest -q -m "not network"`

------
https://chatgpt.com/codex/tasks/task_e_686587e5abe483238b45e3b21ebc3b66