### PR TITLE
Refactor utilities

### DIFF
--- a/fetch_data.py
+++ b/fetch_data.py
@@ -36,16 +36,17 @@ def fetch(
         Mapping of canonical ticker to :class:`pandas.DataFrame` with OHLCV data.
     """
     symbols = [tickers] if isinstance(tickers, str) else list(tickers)
-    if end is None:
-        end = datetime.utcnow().date().isoformat()
+    end = end or datetime.utcnow().date().isoformat()
 
     downloader = DataDownloader()
-    result: dict[str, pd.DataFrame] = {}
-    for sym in symbols:
-        remote = _UCITS.get(sym, sym) if ucits_map else sym
-        df = downloader.get_history(remote, start, end)
-        result[sym] = df
-    return result
+    return {
+        sym: downloader.get_history(
+            _UCITS.get(sym, sym) if ucits_map else sym,
+            start,
+            end,
+        )
+        for sym in symbols
+    }
 
 
 def _main() -> None:

--- a/scripts/backtest.py
+++ b/scripts/backtest.py
@@ -13,14 +13,8 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 from data import DataDownloader
 from engine import Backtester
 from metrics import cagr, max_drawdown
-import strategies
+from strategies import STRATEGIES
 from strategies.base import Strategy
-
-STRATEGIES = {
-    name.removesuffix("Strategy").lower(): getattr(strategies, name)
-    for name in strategies.__all__
-    if name != "STRATEGIES"
-}
 
 
 def generate_param_grid(params: dict[str, Any]) -> list[dict[str, Any]]:
@@ -28,18 +22,9 @@ def generate_param_grid(params: dict[str, Any]) -> list[dict[str, Any]]:
 
     Any value that is a list will be expanded. Single values are kept as-is.
     """
-    keys = list(params.keys())
-    values: list[list[Any]] = []
-    for v in params.values():
-        if isinstance(v, list):
-            values.append(v)
-        else:
-            values.append([v])
-
-    grid = []
-    for combo in itertools.product(*values):
-        grid.append(dict(zip(keys, combo)))
-    return grid
+    keys = list(params)
+    values = [v if isinstance(v, list) else [v] for v in params.values()]
+    return [dict(zip(keys, combo)) for combo in itertools.product(*values)]
 
 
 def load_strategy(name: str, params: dict[str, float]) -> Strategy:

--- a/scripts/signal.py
+++ b/scripts/signal.py
@@ -10,15 +10,9 @@ sys.modules["signal"] = _signal
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 
 from data import DataDownloader  # noqa: E402
-import strategies  # noqa: E402
+from strategies import STRATEGIES  # noqa: E402
 from strategies.base import Strategy  # noqa: E402
 from typing import cast  # noqa: E402
-
-STRATEGIES = {
-    name.removesuffix("Strategy").lower(): getattr(strategies, name)
-    for name in strategies.__all__
-    if name != "STRATEGIES"
-}
 
 
 def load_strategy(name: str) -> Strategy:

--- a/src/data.py
+++ b/src/data.py
@@ -35,10 +35,7 @@ class DataDownloader:
         df = df.rename(columns=lambda c: str(c).lower().replace(" ", "_"))
 
         required = ["open", "high", "low", "close", "adj_close", "volume"]
-        for col in required:
-            if col not in df.columns:
-                df[col] = pd.NA
-        df = df[required]
+        df = df.reindex(columns=required).fillna(pd.NA)
         return df.add_prefix(f"{ticker.lower()}_")
 
     def get_history(


### PR DESCRIPTION
## Summary
- modernize DataDownloader normalization using `reindex`
- simplify `fetch_data.fetch` using a comprehension
- simplify parameter grid generation in `backtest` script
- reuse exported STRATEGIES map in both CLI scripts

## Testing
- `ruff check .`
- `mypy --install-types --non-interactive src`
- `pytest -q -m "not network"`

------
https://chatgpt.com/codex/tasks/task_e_686588e026f08323a577ac44271d1e6f