### PR TITLE
Fix multi-ticker input parsing

### DIFF
--- a/src/data.py
+++ b/src/data.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from pathlib import Path
 from typing import Iterable
+import re
 
 import pandas as pd
 import yfinance as yf
@@ -46,7 +47,10 @@ class DataDownloader:
     ) -> pd.DataFrame:
         """Return historical data for *ticker* between *start* and *end*."""
 
-        tickers = [ticker] if isinstance(ticker, str) else list(ticker)
+        if isinstance(ticker, str):
+            tickers = [t.strip() for t in re.split(r"[,\s]+", ticker) if t.strip()]
+        else:
+            tickers = list(ticker)
 
         remote_map = {t: ticker_map.get(t, t) for t in tickers}
 

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -50,3 +50,34 @@ def test_get_history_single_ticker_columns(monkeypatch, tmp_path):
         "adj_close",
         "volume",
     ]
+
+
+def test_get_history_parses_comma_separated(monkeypatch, tmp_path):
+    downloader = DataDownloader(cache_dir=tmp_path)
+
+    index = pd.date_range("2020-01-01", periods=1, freq="D")
+
+    def fake_download(ticker: str, *args: str, **kwargs: str) -> pd.DataFrame:
+        return pd.DataFrame(
+            {
+                "Open": [1],
+                "High": [2],
+                "Low": [1],
+                "Close": [1],
+                "Adj Close": [1],
+                "Volume": [1],
+            },
+            index=index,
+        )
+
+    monkeypatch.setattr(yf, "download", fake_download)
+
+    df = downloader.get_history("AAA,BBB", "2020-01-01", "2020-01-02")
+    expected_cols = [
+        f"aaa_{c}"
+        for c in ["open", "high", "low", "close", "adj_close", "volume"]
+    ] + [
+        f"bbb_{c}"
+        for c in ["open", "high", "low", "close", "adj_close", "volume"]
+    ]
+    assert list(df.columns) == expected_cols


### PR DESCRIPTION
## Summary
- allow comma separated lists in `DataDownloader.get_history`
- test parsing of comma separated tickers

## Testing
- `ruff check .`
- `mypy`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68658942bde48323a79397ac34796277