### PR TITLE
Fix mypy failure by avoiding broken SciPy stubs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Run ruff
         run: ruff check .
       - name: Run mypy
-        run: mypy --install-types --non-interactive --show-error-codes src
+        run: mypy --show-error-codes src
       - name: Run pytest
         run: pytest -q -m "not network" --cov=src --cov-report=xml --cov-fail-under=90
       - name: Upload coverage artifact


### PR DESCRIPTION
## Summary
- prevent `mypy` from auto-installing stub packages

## Testing
- `ruff check .`
- `mypy --show-error-codes src`
- `pytest -q -m "not network"`

------
https://chatgpt.com/codex/tasks/task_e_68658b8413d48323a48fa4e7b013c024