### PR TITLE
Fix IBSStrategy with prefixed columns

### DIFF
--- a/src/strategies/ibs.py
+++ b/src/strategies/ibs.py
@@ -17,9 +17,24 @@ class IBSStrategy(BaseStrategy):
 
     def next_bar(self, bar: pd.Series[Any]) -> str:
         """Return trading signal based on IBS."""
-        high = float(bar["high"])
-        low = float(bar["low"])
-        close = float(bar["close"])
+        high_col = "high"
+        low_col = "low"
+        close_col = "close"
+
+        if high_col not in bar.index:
+            high_candidates = [c for c in bar.index if c.endswith("_high")]
+            low_candidates = [c for c in bar.index if c.endswith("_low")]
+            close_candidates = [c for c in bar.index if c.endswith("_close")]
+            if high_candidates and low_candidates and close_candidates:
+                high_col = high_candidates[0]
+                low_col = low_candidates[0]
+                close_col = close_candidates[0]
+            else:
+                raise KeyError("Missing high/low/close columns")
+
+        high = float(bar[high_col])
+        low = float(bar[low_col])
+        close = float(bar[close_col])
 
         if high == low:
             ibs = 0.5

--- a/src/strategies/ibs.py
+++ b/src/strategies/ibs.py
@@ -22,13 +22,27 @@ class IBSStrategy(BaseStrategy):
         close_col = "close"
 
         if high_col not in bar.index:
-            high_candidates = [c for c in bar.index if c.endswith("_high")]
-            low_candidates = [c for c in bar.index if c.endswith("_low")]
-            close_candidates = [c for c in bar.index if c.endswith("_close")]
-            if high_candidates and low_candidates and close_candidates:
-                high_col = high_candidates[0]
-                low_col = low_candidates[0]
-                close_col = close_candidates[0]
+            prefixes = {
+                c.removesuffix("_high")
+                for c in bar.index
+                if c.endswith("_high")
+            }
+            prefixes &= {
+                c.removesuffix("_low")
+                for c in bar.index
+                if c.endswith("_low")
+            }
+            prefixes &= {
+                c.removesuffix("_close")
+                for c in bar.index
+                if c.endswith("_close")
+            }
+
+            if len(prefixes) == 1:
+                prefix = prefixes.pop()
+                high_col = f"{prefix}_high"
+                low_col = f"{prefix}_low"
+                close_col = f"{prefix}_close"
             else:
                 raise KeyError("Missing high/low/close columns")
 

--- a/tests/test_ibs.py
+++ b/tests/test_ibs.py
@@ -21,3 +21,16 @@ def test_ibs_signals() -> None:
     signals = [strategy.next_bar(bar) for bar in bars]
 
     assert signals == ["BUY", "SELL", "HOLD"]
+
+
+def test_ibs_prefixed_columns() -> None:
+    strategy = IBSStrategy()
+    bar = pd.Series(
+        {
+            "spy_open": 1,
+            "spy_high": 10,
+            "spy_low": 0,
+            "spy_close": 9,
+        }
+    )
+    assert strategy.next_bar(bar) == "SELL"


### PR DESCRIPTION
## Summary
- make IBSStrategy resilient to DataFrames with ticker prefixes
- install pandas stub types to satisfy mypy

## Testing
- `ruff check .`
- `mypy`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68662561506c83238077f21db5546463