### PR TITLE
Add class reference docs for AI rewriting

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ This repository is a template for a modern Python project. It includes linting w
 Code is formatted with [Black](https://black.readthedocs.io/) and these checks run automatically via [pre-commit](https://pre-commit.com/).
 
 Use this setup as a starting point for new projects that require a light-weight but strict development workflow.
+See the [Class Intent Reference](docs/class_intent.md) for a summary of all
+classes and their roles in the current code base.
 
 ## Running the Scripts
 

--- a/docs/class_intent.md
+++ b/docs/class_intent.md
@@ -1,0 +1,64 @@
+# Class Intent Reference
+
+This document summarises the purpose of each class in the current code base. It can be used by AI agents when rewriting the framework from scratch.
+
+## Core Utilities
+
+### `DataDownloader`
+Source: `src/data.py`
+
+Downloads and caches historical OHLCV price data using **yfinance**. Normalises columns, fills missing required columns, and stores per-ticker parquet files in a cache directory.
+
+### `Backtester`
+Source: `src/engine.py`
+
+Runs a simple long-only back-test over historical data. It feeds each bar into a strategy, executes buy/sell signals, maintains equity and drawdown, and records trades.
+
+### `PromptEntry`
+Source: `analyze_cognitive_load.py`
+
+Dataclass for log entries produced by `track_prompt.py`. Captures timestamp, prompt complexity and quality for monitoring cognitive load.
+
+## Strategy Base Classes
+
+### `Strategy`
+Source: `src/strategies/base.py`
+
+Abstract base class for trading strategies. Provides parameter storage, position tracking and a `next_bar` interface that returns a signal string or weight mapping.
+
+### `HistoryStrategy`
+Source: `src/strategies/base.py`
+
+Extends `Strategy` with a history of closing prices. Useful for strategies that require look-back calculations.
+
+## Concrete Strategies
+
+Classes below implement `next_bar` to produce trading signals.
+
+- **`BreakoutStrategy`** (`src/strategies/breakout.py`)
+  - Weekly 52‑week high breakout with trailing stop.
+- **`BollingerStrategy`** (`src/strategies/bollinger.py`)
+  - Mean reversion using weekly Bollinger Bands.
+- **`DualMomentumStrategy`** (`src/strategies/dual_mom.py`)
+  - Rotates into top‑performing ETFs on a monthly basis.
+- **`IBSStrategy`** (`src/strategies/ibs.py`)
+  - Trades based on Internal Bar Strength thresholds.
+- **`MACDStrategy`** (`src/strategies/macd.py`)
+  - Uses MACD crosses on weekly data to enter/exit.
+- **`RSIStrategy`** (`src/strategies/rsi.py`)
+  - Mean reversion using weekly RSI levels.
+- **`LeveragedTrendStrategy`** (`src/strategies/leveragedtrend.py`)
+  - Trend following on a leveraged S&P 500 ETF based on a moving average.
+- **`HFEA55Strategy`** (`src/strategies/hfea55.py`)
+  - Maintains a 55/45 leveraged stock/bond allocation rebalanced monthly.
+- **`CoveredCallMedianStrategy`** (`src/strategies/median_cc.py`)
+  - Buys or sells a covered‑call ETF when price deviates from its rolling median.
+- **`EndOfMonthBondPopStrategy`** (`src/strategies/eom_bond.py`)
+  - Holds a Treasury ETF only during the last few trading days of each month.
+
+## Code Quality & Testing
+
+- Linting via **Ruff** and static typing via **mypy**. Configuration in `pyproject.toml`.
+- Unit tests live in `tests/` and are run with **pytest**. Coverage settings are also in `pyproject.toml`.
+- Before committing, run `ruff check .`, `mypy` and `pytest -q` to ensure quality and test coverage.
+


### PR DESCRIPTION
## Summary
- document intent of each class in new `docs/class_intent.md`
- link documentation from README

## Testing
- `ruff check .`
- `mypy`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686796eb87308323bb4f6f25962d12f7