### PR TITLE
Add detailed module documentation

### DIFF
--- a/docs/analyze_cognitive_load.md
+++ b/docs/analyze_cognitive_load.md
@@ -1,0 +1,15 @@
+# analyze_cognitive_load.py
+
+Parses `logs/prompt_log.md` produced by `track_prompt.py` and checks for
+potential cognitive overload situations. It reads optional thresholds from
+`tracker_config.yaml` and touches `.you-need-a-break` when the limits are
+exceeded.
+
+## Functions
+- `parse_logs(path)` – return a list of `PromptEntry` records from the markdown log
+- `load_config()` – load limit values from `tracker_config.yaml`
+- `analyze(entries, config)` – apply heuristics and return `True` when overload
+  is detected
+
+Running the script exits with code 1 and prints a warning when overload is
+found.

--- a/docs/backtest.md
+++ b/docs/backtest.md
@@ -1,0 +1,22 @@
+# backtest.py
+
+Command line script to run back-tests for the trading strategies defined in `src/strategies`.
+It downloads historical data with `DataDownloader`, feeds each bar into a `Backtester`
+instance and prints a performance summary. Parameters may be supplied as JSON and
+expanded into a grid when `--sweep` is used.
+
+## Usage
+
+```bash
+PYTHONPATH=./src python backtest.py --strategy rsi --ticker AAPL --start 2020-01-01 --end 2021-01-01 --params '{"rsi_buy": 30, "rsi_sell": 70}'
+```
+
+### Arguments
+- `--strategy` – name of a strategy to run (exclusive with `--all`)
+- `--all` – run all available strategies
+- `--ticker` – ticker symbol to back-test
+- `--start`/`--end` – ISO date range for the test
+- `--params` – JSON string of strategy parameters
+- `--sweep` – run all combinations of the parameter grid
+
+Results are written to `results/` with the parameter hash in the filename.

--- a/docs/data.md
+++ b/docs/data.md
@@ -1,0 +1,14 @@
+# data.py
+
+Implements `DataDownloader`, a simple wrapper around the `yfinance` library.
+It caches downloaded OHLCV data as parquet files under `data/` to avoid
+repeated network requests. Columns are normalised to lowercase names and ticker
+prefixes.
+
+```python
+from data import DataDownloader
+loader = DataDownloader()
+df = loader.get_history("SPY", "2020-01-01", "2020-12-31")
+```
+
+The `ticker_map` dictionary defines UCITS equivalents for some common US ETFs.

--- a/docs/engine.md
+++ b/docs/engine.md
@@ -1,0 +1,15 @@
+# engine.py
+
+Contains the `Backtester` class used to simulate trading strategies on historical
+data. For each bar it calls the strategy's `next_bar` method, updates equity and
+records trades. The backtester supports both single-asset and multi-asset
+strategies that return weight dictionaries.
+
+```python
+from engine import Backtester
+bt = Backtester(my_strategy, price_dataframe)
+results = bt.run()
+```
+
+The resulting DataFrame includes columns for price, position, emitted signal,
+current equity and drawdown.

--- a/docs/fetch.md
+++ b/docs/fetch.md
@@ -1,0 +1,19 @@
+# fetch.py
+
+CLI wrapper for `fetch_data.fetch()`.
+Allows pulling historical prices for a comma-separated list of tickers and
+optionally writing them to CSV files or printing JSON to stdout.
+
+## Example
+
+```bash
+python fetch.py --tickers "SPY,IDTL" --start 2020-01-01 --end 2020-06-30 --csv-out data
+```
+
+### Options
+- `--tickers` – comma separated symbols (required)
+- `--start` / `--end` – ISO date range
+- `--interval` – bar interval (passed through)
+- `--ucits-off` – disable UCITS ticker mapping
+- `--csv-out` – directory to write CSV files
+- `--json` – print data as JSON on stdout

--- a/docs/fetch_data.md
+++ b/docs/fetch_data.md
@@ -1,0 +1,19 @@
+# fetch_data.py
+
+Lightweight helper around `DataDownloader` providing a `fetch()` function.
+It accepts one or more ticker symbols and returns a dictionary of
+`pandas.DataFrame` objects with OHLCV data.
+
+When run as `python -m fetch_data TICKER ...` it writes the data to CSV files in
+the current directory.
+
+```python
+from fetch_data import fetch
+prices = fetch(["SPY", "AAPL"], start="2020-01-01", end="2020-12-31")
+```
+
+### Parameters
+- `tickers` – single symbol or iterable of symbols
+- `start` / `end` – ISO date range
+- `interval` – bar interval (currently unused)
+- `ucits_map` – map US tickers to UCITS equivalents when `True`

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -1,0 +1,9 @@
+# metrics.py
+
+Utility functions for evaluating back-test results.
+
+- `cagr(equity, start, end)` – Compound Annual Growth Rate
+- `sharpe_ratio(returns, risk_free_rate=0.0, periods_per_year=252)`
+- `max_drawdown(drawdown)` – minimum value of a drawdown series
+
+All functions accept pandas series and return a float.

--- a/docs/signal.md
+++ b/docs/signal.md
@@ -1,0 +1,18 @@
+# signal.py
+
+Utility script to show the latest trading signal produced by a strategy.
+It downloads recent price history via `DataDownloader` and feeds it to the chosen
+strategy's `next_bar` method.
+
+Run for a single strategy or all available ones:
+
+```bash
+PYTHONPATH=./src python signal.py --strategy rsi --ticker AAPL
+PYTHONPATH=./src python signal.py --all --ticker AAPL
+```
+
+### Arguments
+- `--strategy` – name of a strategy to run
+- `--all` – run every strategy defined in `strategies`
+- `--ticker` – ticker symbol to evaluate
+- `--lookback` – number of days of history to download

--- a/docs/strategies.md
+++ b/docs/strategies.md
@@ -1,13 +1,49 @@
 # Strategies
 
+## BreakoutStrategy
+Trades weekly 52‑week high breakouts with a trailing stop. Parameters
+`lookback_weeks` and `stop_pct` control the lookback window and stop distance.
+
+## BollingerStrategy
+Mean-reversion strategy based on weekly Bollinger Bands. Parameters `length` and
+`dev` set the moving average length and band deviation.
+
+## DualMomentumStrategy
+Rotates among a universe of ETFs each month by selecting the top performers over
+a configurable lookback. Takes the first `top_k` tickers with positive momentum.
+
+## IBSStrategy
+Uses Internal Bar Strength (IBS) calculated from the day's high, low and close
+to trigger overbought/oversold signals. Thresholds are `buy_thr` and `sell_thr`.
+
+## MACDStrategy
+Classic MACD crossover system using weekly data. Parameters `fast`, `slow` and
+`signal` configure the moving average lengths.
+
+## RSIStrategy
+Weekly RSI mean-reversion rules. Buy when RSI <= `rsi_buy` and sell when RSI >=
+`rsi_sell`.
+
 ## LeveragedTrendStrategy
-Long the Xtrackers S&P 500 2× (ISIN LU0411078552) when the close is above its 200‑day simple moving average. Otherwise stay in cash. Parameter `sma_len` controls the SMA length in days.
+Long the Xtrackers S&P 500 2× (ISIN LU0411078552) when the close is above its
+`200`‑day simple moving average. Otherwise stay in cash. Parameter `sma_len`
+controls the SMA length in days.
 
 ## HFEA55Strategy
-Allocates 55 % to WisdomTree S&P 500 3× (ISIN IE00B7KQZF44, ticker `3USL`) and 45 % to WisdomTree 10‑Yr Treasury 3× (ISIN IE00BKT09032, ticker `3TYL`). The portfolio is rebalanced at each month end. Parameter `rebalance_days` sets the minimum business days between rebalances.
+Allocates 55 % to WisdomTree S&P 500 3× (ISIN IE00B7KQZF44, ticker `3USL`) and
+45 % to WisdomTree 10‑Yr Treasury 3× (ISIN IE00BKT09032, ticker `3TYL`). The
+portfolio is rebalanced at each month end. Parameter `rebalance_days` sets the
+minimum business days between rebalances.
 
 ## CoveredCallMedianStrategy
-Trades the Global X S&P 500 Covered Call UCITS ETF (ISIN IE00BKT6Q882, ticker `XYLU`) using a 60‑day rolling median. Buy when price is below `(1 − band)` times the median and sell when above `(1 + band)` times the median. Parameter `band` is expressed as a percent.
+Trades the Global X S&P 500 Covered Call UCITS ETF (ISIN IE00BKT6Q882, ticker
+`XYLU`) using a 60‑day rolling median. Buy when price is below `(1 − band)` times
+ the median and sell when above `(1 + band)` times the median. Parameter `band` is
+expressed as a percent.
 
 ## EndOfMonthBondPopStrategy
-Holds the iShares $ Treasury 20+ yr UCITS ETF (ISIN IE00B1FZS806, ticker `IDTL`) only for the final `hold_days` trading days of each calendar month.
+Holds the iShares $ Treasury 20+ yr UCITS ETF (ISIN IE00B1FZS806, ticker `IDTL`)
+only for the final `hold_days` trading days of each calendar month.
+
+## Module initialisation
+The `src/strategies/__init__.py` file registers all strategy classes in the `STRATEGIES` dictionary and exposes them via `__all__`.

--- a/docs/streamlit_app.md
+++ b/docs/streamlit_app.md
@@ -1,0 +1,17 @@
+# streamlit_app.py
+
+Interactive web interface built with Streamlit. Users can select a strategy,
+enter parameters and run a back-test or show the latest signal directly in the
+browser. The app uses Plotly for charts and displays common performance metrics
+(CAGR, maximum drawdown, Sharpe ratio).
+
+Launch with:
+
+```bash
+streamlit run streamlit_app.py
+```
+
+### Features
+- Parameter inputs are generated from the strategy constructor signature.
+- Data is cached to speed up repeated runs.
+- Buttons allow running back-tests or viewing signals without leaving the page.

--- a/docs/track_prompt.md
+++ b/docs/track_prompt.md
@@ -1,0 +1,18 @@
+# track_prompt.py
+
+Small command line utility to record developer prompts for later analysis.
+It appends metadata such as a complexity score, readability estimate and token
+count to `logs/prompt_log.md`.
+
+Typical invocation:
+
+```bash
+python track_prompt.py --prompt "Add unit tests" --session-id 123
+```
+
+### Options
+- `--prompt` – text of the prompt to record (required)
+- `--session-id` – unique session identifier
+- `--project` – project name (default: `unknown`)
+- `--file` – file name (default: `unknown`)
+- `--log` – path to the log file


### PR DESCRIPTION
## Summary
- add docs for main scripts (`fetch.py`, `backtest.py`, etc.)
- document internal modules (`data.py`, `engine.py`, `metrics.py`)
- expand `docs/strategies.md` to cover all strategies and note module init

## Testing
- `ruff check .`
- `mypy`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68681cc087648323b963d1a3a4685c09