### PR TITLE
Fix CLI import paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@ classes and their roles in the current code base.
 
 ## Running the Scripts
 
-Install the dependencies first:
+Install the dependencies first (including PDF/OCR tools):
 
 ```bash
-pip install -e .[dev]
+pip install -e .[dev,pdf]
 ```
 
 Set up the pre-commit hooks after installing the requirements:
@@ -72,6 +72,22 @@ Fetch price history from the command line:
 ```bash
 python fetch.py --tickers "SPY,IDTL" --start 2020-01-01 --end 2020-01-10 \
   --csv-out data
+```
+
+## PDF text extraction
+
+Extract text from a PDF, falling back to OCR for scanned documents:
+
+```bash
+python extract_pdf.py path/to/file.pdf --output out.txt --lang eng
+```
+
+## Glossary translator
+
+Translate phrases using a two-column CSV glossary:
+
+```bash
+python translate.py --glossary glossary.csv --text "hello" --reverse
 ```
 
 ## Checking code quality

--- a/extract_pdf.py
+++ b/extract_pdf.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import sys
+from pathlib import Path as _Path
+
+# Allow running without installing the package
+repo_root = _Path(__file__).resolve().parent
+sys.path.insert(0, str(repo_root / "src"))
+
+from pdfextractor import extract_text_from_pdf  # noqa: E402
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Extract text from a PDF using pdfminer or OCR"
+    )
+    parser.add_argument("pdf", type=Path, help="Path to PDF file")
+    parser.add_argument(
+        "-o", "--output", type=Path, required=True, help="Output text file"
+    )
+    parser.add_argument(
+        "--lang",
+        default="eng",
+        help="Tesseract language code for OCR",
+    )
+    args = parser.parse_args()
+
+    text = extract_text_from_pdf(args.pdf, ocr_lang=args.lang)
+    args.output.write_text(text, encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,10 +25,22 @@ dev = [
     "pre-commit==4.2.0",
     "grimp==3.9",
     "types-PyYAML==6.0.12.20250516",
+    "pdfminer.six==20250506",
+    "pdf2image==1.17.0",
+    "pytesseract==0.3.13",
+    "Pillow==11.3.0",
+    "fpdf2==2.8.3",
 ]
 streamlit = [
     "streamlit==1.46.1",
     "plotly==6.2.0",
+]
+pdf = [
+    "pdfminer.six==20250506",
+    "pdf2image==1.17.0",
+    "pytesseract==0.3.13",
+    "Pillow==11.3.0",
+    "fpdf2==2.8.3",
 ]
 
 [tool.ruff]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,1 +1,1 @@
--e .[dev]
+-e .[dev,pdf]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
--e .[streamlit]
+-e .[streamlit,pdf]

--- a/src/pdfextractor.py
+++ b/src/pdfextractor.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from pdfminer.high_level import extract_text as pdfminer_extract_text
+from pdf2image import convert_from_path
+import pytesseract  # type: ignore[import-untyped]
+
+
+def extract_text_from_pdf(path: Path, *, ocr_lang: str = "eng") -> str:
+    """Return text content from *path*.
+
+    First attempts direct extraction using :mod:`pdfminer`. If that yields no
+    text, fall back to OCR using :mod:`pytesseract`.
+    """
+    text = pdfminer_extract_text(str(path))
+    if text.strip():
+        return text
+    images = convert_from_path(str(path))
+    ocr_text = "\n".join(
+        pytesseract.image_to_string(image, lang=ocr_lang) for image in images
+    )
+    return ocr_text

--- a/src/translator.py
+++ b/src/translator.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+
+
+def load_glossary(path: Path) -> dict[str, str]:
+    """Return a dictionary mapping English terms to Hungarian."""
+    with path.open(newline="", encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        if reader.fieldnames is None or set(reader.fieldnames) != {"en", "hu"}:
+            raise ValueError("Glossary must have 'en' and 'hu' columns")
+        glossary: dict[str, str] = {}
+        for row in reader:
+            en = row.get("en") or ""
+            hu = row.get("hu") or ""
+            if en:
+                glossary[en.strip().lower()] = hu.strip()
+    return glossary
+
+
+def translate_text(
+    text: str, glossary: dict[str, str], *, reverse: bool = False
+) -> str:
+    """Translate a space-separated text using *glossary*.
+
+    If *reverse* is True, translate Hungarian to English."""
+    dictionary = glossary if not reverse else {v: k for k, v in glossary.items()}
+    words = text.split()
+    translated = [dictionary.get(w.lower(), w) for w in words]
+    return " ".join(translated)
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Simple glossary-based translator"
+    )
+    parser.add_argument(
+        "glossary", type=Path, help="CSV file with 'en' and 'hu' columns"
+    )
+    parser.add_argument("text", help="Text to translate")
+    parser.add_argument("--reverse", action="store_true", help="Translate hu->en")
+    args = parser.parse_args()
+
+    glossary = load_glossary(args.glossary)
+    result = translate_text(args.text, glossary, reverse=args.reverse)
+    print(result)

--- a/tests/test_pdfextractor.py
+++ b/tests/test_pdfextractor.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from PIL import Image, ImageDraw
+from fpdf import FPDF
+import shutil
+import pytest
+
+requires_tesseract = pytest.mark.skipif(
+    shutil.which("tesseract") is None,
+    reason="tesseract binary not available",
+)
+
+# ensure src path
+project_root = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(project_root / "src"))
+sys.path.insert(0, str(project_root))
+
+import pdfextractor  # noqa: E402
+import extract_pdf as extract_cli  # noqa: E402
+
+
+def create_text_pdf(path: Path, text: str) -> None:
+    pdf = FPDF()
+    pdf.add_page()
+    pdf.set_font("Arial", size=12)
+    pdf.cell(200, 10, txt=text, ln=True)
+    pdf.output(str(path))
+
+
+def create_image_pdf(path: Path, text: str) -> None:
+    img = Image.new("RGB", (200, 50), "white")
+    d = ImageDraw.Draw(img)
+    d.text((10, 10), text, fill="black")
+    img_path = path.with_suffix(".png")
+    img.save(img_path)
+    pdf = FPDF()
+    pdf.add_page()
+    pdf.image(str(img_path), x=10, y=10, w=100)
+    pdf.output(str(path))
+    img_path.unlink()
+
+
+def test_extract_text_direct(tmp_path: Path) -> None:
+    pdf_file = tmp_path / "direct.pdf"
+    create_text_pdf(pdf_file, "Hello world")
+    result = pdfextractor.extract_text_from_pdf(pdf_file)
+    assert "Hello world" in result
+
+
+@requires_tesseract
+def test_extract_text_ocr(tmp_path: Path) -> None:
+    pdf_file = tmp_path / "ocr.pdf"
+    create_image_pdf(pdf_file, "OCR test")
+    result = pdfextractor.extract_text_from_pdf(pdf_file)
+    assert "OCR" in result
+
+
+def test_cli_output(tmp_path: Path) -> None:
+    pdf_file = tmp_path / "cli.pdf"
+    create_text_pdf(pdf_file, "CLI works")
+    out_file = tmp_path / "out.txt"
+    argv = [
+        "extract_pdf.py",
+        str(pdf_file),
+        "--output",
+        str(out_file),
+    ]
+    sys.argv = argv
+    extract_cli.main()
+    content = out_file.read_text(encoding="utf-8")
+    assert "CLI works" in content

--- a/tests/test_translator.py
+++ b/tests/test_translator.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+# Ensure src package is on path
+project_root = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(project_root / "src"))
+sys.path.insert(0, str(project_root))
+
+import translator  # noqa: E402
+import translate as translate_cli  # noqa: E402
+
+
+def test_load_glossary(tmp_path: Path) -> None:
+    csv_file = tmp_path / "glossary.csv"
+    csv_file.write_text("en,hu\nhello,szia\nworld,vilag\n", encoding="utf-8")
+    result = translator.load_glossary(csv_file)
+    assert result == {"hello": "szia", "world": "vilag"}
+
+
+def test_translate_text() -> None:
+    glossary = {"hello": "szia", "world": "vilag"}
+    translated = translator.translate_text("hello world", glossary)
+    assert translated == "szia vilag"
+
+
+def test_translate_cli(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    csv_file = tmp_path / "g.csv"
+    csv_file.write_text("en,hu\nhello,szia\n", encoding="utf-8")
+    argv = [
+        "translate.py",
+        "--glossary",
+        str(csv_file),
+        "--text",
+        "hello",
+    ]
+    sys.argv = argv
+    translate_cli.main()
+    out = capsys.readouterr().out.strip()
+    assert out == "szia"

--- a/translate.py
+++ b/translate.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import sys
+from pathlib import Path as _Path
+
+# Allow running without installing the package
+repo_root = _Path(__file__).resolve().parent
+sys.path.insert(0, str(repo_root / "src"))
+
+from translator import load_glossary, translate_text  # noqa: E402
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Translate text using a CSV glossary"
+    )
+    parser.add_argument(
+        "--glossary",
+        required=True,
+        type=Path,
+        help="CSV file with 'en' and 'hu' columns",
+    )
+    parser.add_argument("--text", required=True, help="Text to translate")
+    parser.add_argument("--reverse", action="store_true", help="Translate hu->en")
+    args = parser.parse_args()
+
+    glossary = load_glossary(args.glossary)
+    result = translate_text(args.text, glossary, reverse=args.reverse)
+    print(result)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- adjust `extract_pdf.py` and `translate.py` to add `src` to `sys.path`
- maintain E402 rules via noqa
- add OCR dependencies in `pyproject.toml`
- update requirements files and README with CLI usage
- skip OCR test when tesseract isn't installed

## Testing
- `ruff check .`
- `mypy extract_pdf.py translate.py src`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e8a81f47c8323972bcd0832752ad0